### PR TITLE
refactor: configure Mongo via env; improve test automation and deploy…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,48 +17,70 @@ Currently only uses commands, we will need to integrate better calls
 
 ## Example - Testing
 
+All helper scripts and the `mongoclient` image live under [`test/`](test/).
 
-### Database
+### One-shot local Mongo seed (recommended)
 
-* Spin up the test database to use collections
+[`test/run_tests.sh`](test/run_tests.sh) creates a Docker network, starts **MongoDB Community** in a container, waits until it is ready, builds the **mongoclient** image, and runs [`test/setup_mongo.sh`](test/setup_mongo.sh) inside that image. It is **non-interactive** and suitable for CI.
 
-```
-$ docker run --rm -it --name mongodb -p 27017:27017 -d mongodb/mongodb-community-server:latest
-```
-
-* Run the test script to setup mongodb collections
-
-```
-$ docker build -t mongoclient -f mongoclient.dockerfile .
-
-$ docker run --rm -it  mongoclient
+```bash
+cd test
+./run_tests.sh
 ```
 
-* Spin up the test client to work with the database
+By default the Mongo container is removed when the script exits. To leave it running on `localhost:27017` for manual work:
 
+```bash
+KEEP_MONGO=1 ./run_tests.sh
 ```
-$ docker run --rm -it --entrypoint=bash  mongoclient
 
-$ mongosh mongodb://172.17.0.2:27017
+Useful environment variables (both scripts honor the overlapping ones):
+
+| Variable | Purpose |
+|----------|---------|
+| `MONGO_HOST` / `MONGO_PORT` | Mongo host and port (defaults: in-cluster service DNS for `setup_mongo.sh`; `run_tests.sh` sets host to the Mongo container name on the test network) |
+| `MONGO_ADMIN_USER` / `MONGO_ADMIN_PASSWORD` | Root user for seeding (defaults match Docker `MONGO_INITDB_*` in `run_tests.sh`) |
+| `MONGO_API_USER` / `MONGO_API_PASSWORD` | Application user created in `api_db` (defaults: `api_user` / `api_mongoApiPassword`) |
+| `IMPORT_DATA_JSON` | Set to `0` to skip importing [`test/data.json`](test/data.json) |
+| `DATA_JSON` | Path to JSON array file for `mongoimport` (default: `test/data.json` beside the script) |
+| `DATA_JSON_COLLECTION` | Target collection for that import (default: `seed_docs`) |
+| `DOCKER_NETWORK` / `MONGO_CONTAINER` | Override Docker network name and Mongo container name in `run_tests.sh` |
+| `KEEP_MONGO` | `1` = do not remove the Mongo container on exit |
+| `KEEP_TEST_NETWORK` | `1` = skip removing the test Docker network when cleaning up (only if `KEEP_MONGO` is not used) |
+
+[`test/setup_mongo.sh`](test/setup_mongo.sh) creates `api_db` with `clients`, `heartbeat`, and `data` collections (plus indexes and sample documents). [`test/data.json`](test/data.json) is imported as **extra** seed documents into `seed_docs`; it does not replace the scripted fixture data.
+
+**Kubernetes:** exec into a pod that has `mongosh` and this repo (or use the mongoclient image), then point at your cluster service, for example:
+
+```bash
+export MONGO_HOST=mongodb-service.reaperc2-ns.svc.cluster.local
+export MONGO_PORT=27017
+./setup_mongo.sh
 ```
+
+**Manual Docker** (if you do not use `run_tests.sh`): build and run from `test/` with `MONGO_HOST` set to a resolvable hostname for the Mongo container on the same Docker network.
 
 ### Server
 
-* Open pkg/dbconnections/mongoconnections.go and uncomment the Docker IP
+The server reads Mongo settings from environment variables (see [`pkg/dbconnections/mongoconnections.go`](pkg/dbconnections/mongoconnections.go)). After seeding with the defaults above, run locally against Docker Mongo on the published port:
+
+```bash
+export DEPLOY_ENV=ONPREM
+export MONGO_HOST=127.0.0.1
+export MONGO_PORT=27017
+export MONGO_USERNAME=api_user
+export MONGO_PASSWORD=api_mongoApiPassword
+export MONGO_DATABASE=api_db
+
+cd cmd && env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -v -o ReaperC2
+./ReaperC2
+```
+
+Example log lines:
 
 ```
-	//mongoFqdn           = "mongodb-service.reaperc2-ns.svc.cluster.local"
-	mongoFqdn        = "172.17.0.2"
-```
-
-* Build and run the Server
-
-```
-$ env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -v -o ReaperC2
-
-$ ./ReaperC2 
-2025/03/17 22:41:52 Connected to MongoDB!
-2025/03/17 22:41:52 Server running on port 8080...
+Connected to MongoDB!
+Server running on port 8080...
 ```
 
 ### Client

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,16 +13,16 @@ func main() {
 	deployEnv := deploymehere.GetDeploymentEnv()
 	switch deployEnv {
 	case "AWS":
-		dbconnections.InitMongoDB(dbconnections.DocumentDBURI)
+		dbconnections.InitMongoDB(deployEnv)
 		apiserver.StartAPIServer()
 	case "AZURE":
 		log.Println("AZURE: Coming soon")
 	case "GCP":
 		log.Println("GCP: Coming soon")
 	case "ONPREM":
-		dbconnections.InitMongoDB(dbconnections.MongoURI)
+		dbconnections.InitMongoDB(deployEnv)
 		apiserver.StartAPIServer()
 	default:
-		log.Println("Uknown Environment")
+		log.Println("Unknown Environment")
 	}
 }

--- a/deployments/k8s/AWS/full-deployment.yaml
+++ b/deployments/k8s/AWS/full-deployment.yaml
@@ -12,6 +12,18 @@ data:
   .dockerconfigjson: {{ cat ~/.docker/config.json | base64 -w 0 }}
 type: kubernetes.io/dockerconfigjson
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: reaperc2-mongodb-credentials
+  namespace: reaperc2-ns
+type: Opaque
+stringData:
+  mongo-host: "YOUR_DOCUMENTDB_CLUSTER_ENDPOINT.cluster-XXXXXXXX.us-east-1.docdb.amazonaws.com"
+  mongo-username: "api_user"
+  mongo-password: "YOUR_MONGO_PASSWORD"
+  mongo-database: "api_db"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,6 +54,33 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+          env:
+            - name: DEPLOY_ENV
+              value: "AWS"
+            - name: MONGO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: reaperc2-mongodb-credentials
+                  key: mongo-host
+            - name: MONGO_PORT
+              value: "27017"
+            - name: MONGO_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: reaperc2-mongodb-credentials
+                  key: mongo-username
+            - name: MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: reaperc2-mongodb-credentials
+                  key: mongo-password
+            - name: MONGO_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: reaperc2-mongodb-credentials
+                  key: mongo-database
+            - name: MONGO_TLS_CA_FILE
+              value: "/etc/ssl/certs/rds-combined-ca-bundle.pem"
           volumeMounts:
             - name: docdb-ca-volume
               mountPath: /etc/ssl/certs/rds-combined-ca-bundle.pem

--- a/deployments/k8s/DigitalOcean/README.md
+++ b/deployments/k8s/DigitalOcean/README.md
@@ -1,13 +1,108 @@
-# Usage
+# DigitalOcean: Kubernetes and MongoDB (Terraform)
 
-```
-export DIGITALOCEAN_TOKEN="your_do_token"
+This directory provisions **supporting infrastructure** for ReaperC2 on DigitalOcean: a VPC, a DigitalOcean Kubernetes (DOKS) cluster, and a **managed MongoDB** instance attached to the same VPC so the cluster can reach the database over the private network.
+
+Application manifests (Deployments, Services, Ingress, etc.) live under `deployments/k8s/` elsewhere; use those as a template after the cluster exists.
+
+## What Terraform creates
+
+| Resource | Details |
+|----------|---------|
+| VPC | `do-k8s-vpc` in `var.region` |
+| Kubernetes | Cluster `my-k8s-cluster`, Kubernetes version `latest`, 2× `s-1vcpu-2gb` worker nodes |
+| MongoDB | Managed cluster `mongo-cluster`, MongoDB 6, `db-s-1vcpu-1gb`, 1 node, 15 GiB storage, same VPC |
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) ≥ 1.0
+- A DigitalOcean account and [API token](https://docs.digitalocean.com/reference/api/create-personal-access-token/) with read/write access
+- Optional: `kubectl` if you will deploy workloads immediately after
+
+## Configure and apply
+
+From this directory:
+
+```bash
+export DIGITALOCEAN_TOKEN="your_personal_access_token"
+# Optional: export TF_VAR_do_token="$DIGITALOCEAN_TOKEN" instead of passing -var below
 
 terraform init
 
-terraform plan -out=tfplan
+terraform plan -out=tfplan -var "do_token=$DIGITALOCEAN_TOKEN"
 
-terraform apply -var "do_token=$DIGITALOCEAN_TOKEN"
-
-terraform output kubeconfig > ~/.kube/config
+terraform apply tfplan
 ```
+
+Or apply in one step without a saved plan:
+
+```bash
+terraform apply -var "do_token=$DIGITALOCEAN_TOKEN"
+```
+
+### Region
+
+Default region is `nyc3`. Override in `variables.tf` or on the CLI:
+
+```bash
+terraform plan -out=tfplan \
+  -var "do_token=$DIGITALOCEAN_TOKEN" \
+  -var "region=lon1"
+terraform apply tfplan
+```
+
+## Outputs
+
+After apply, Terraform exposes:
+
+- **`kubeconfig`**: raw DOKS kubeconfig (marked sensitive).
+- **`mongodb_private_uri`**: private connection URI for the managed MongoDB (sensitive).
+
+View without printing secrets to the screen unnecessarily:
+
+```bash
+terraform output
+```
+
+Write kubeconfig to a **dedicated file** (recommended instead of overwriting `~/.kube/config`):
+
+```bash
+terraform output -raw kubeconfig > ./kubeconfig-do.yaml
+export KUBECONFIG="$(pwd)/kubeconfig-do.yaml"
+kubectl get nodes
+```
+
+If you already use another cluster, either swap `KUBECONFIG` per shell or merge contexts with `kubectl config` — avoid blindly redirecting to `~/.kube/config` unless that file is disposable.
+
+Fetch the Mongo URI when scripting:
+
+```bash
+terraform output -raw mongodb_private_uri
+```
+
+## Deploying ReaperC2 on this cluster
+
+1. **Build and push** a container image to a registry your DOKS nodes can pull (DigitalOcean Container Registry, Docker Hub, etc.) and create an `imagePullSecret` if the registry is private.
+
+2. **Environment**: ReaperC2’s valid `DEPLOY_ENV` values today are `AWS`, `AZURE`, `GCP`, and `ONPREM` (`pkg/deploymehere/deploymehere.go`). For DigitalOcean, use **`ONPREM`** unless you add a dedicated value in code. That path uses the standard MongoDB URI builder (not AWS DocumentDB TLS defaults).
+
+3. **MongoDB variables**: Map your managed DB credentials into the same env vars used in other manifests (`MONGO_HOST`, `MONGO_PORT`, `MONGO_USERNAME`, `MONGO_PASSWORD`, `MONGO_DATABASE`). Derive them from the DigitalOcean control panel or from `mongodb_private_uri`.  
+   DigitalOcean managed databases commonly require TLS; if connections fail, set **`MONGO_USE_TLS=true`** (see `pkg/dbconnections/mongoconnections.go`).
+
+4. **Manifests**: Start from `deployments/k8s/OnPrem/full-deployment.yaml` or `deployments/k8s/AWS/full-deployment.yaml` and replace registry URLs, secrets, and resource sizes for your image and DO networking.
+
+Because the database is on the **VPC private network**, use the **private** host/URI from DigitalOcean for traffic from pods inside this cluster.
+
+## Tear down
+
+```bash
+terraform destroy -var "do_token=$DIGITALOCEAN_TOKEN"
+```
+
+Confirm you are destroying the intended resources; this removes the cluster, database, and VPC created by this configuration.
+
+## Files
+
+- `main.tf` — VPC, DOKS, managed MongoDB, outputs  
+- `variables.tf` — `do_token`, `region`  
+
+For DigitalOcean-specific product docs, see [Kubernetes](https://docs.digitalocean.com/products/kubernetes/) and [Managed Databases](https://docs.digitalocean.com/products/databases/).

--- a/deployments/k8s/OnPrem/full-deployment.yaml
+++ b/deployments/k8s/OnPrem/full-deployment.yaml
@@ -165,6 +165,25 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+          env:
+            - name: DEPLOY_ENV
+              value: "ONPREM"
+            - name: MONGO_HOST
+              value: "mongodb-service.reaperc2-ns.svc.cluster.local"
+            - name: MONGO_PORT
+              value: "27017"
+            - name: MONGO_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: reaperc2-mongodb-secrets
+                  key: api_db-user-secret
+            - name: MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: reaperc2-mongodb-secrets
+                  key: api_dp-user-password-secret
+            - name: MONGO_DATABASE
+              value: "api_db"
       imagePullSecrets:
       - name: reaperc2-myregistrykey
 ---

--- a/pkg/dbconnections/mongoconnections.go
+++ b/pkg/dbconnections/mongoconnections.go
@@ -2,7 +2,10 @@ package dbconnections
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -20,16 +23,6 @@ type ClientAuth struct {
 
 // MongoDB connection details
 const (
-	mongoApiUsername    = "api_user"
-	mongoApiPassword    = "api_mongoApiPassword"
-	databaseName        = "api_db"
-	mongoFqdn           = "mongodb-service.reaperc2-ns.svc.cluster.local"
-	mongoPort           = "27017"
-	mongoDockerFqdn     = "172.17.0.2"
-	MongoURI            = "mongodb://" + mongoApiUsername + ":" + mongoApiPassword + "@" + mongoFqdn + ":" + mongoPort + "/" + databaseName
-	documentDBFQDN      = "test-cluster.cluster-XXXXXXXX.us-east-1.docdb.amazonaws.com"
-	documentDBConString = "?ssl=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
-	DocumentDBURI       = "mongodb://" + mongoApiUsername + ":" + mongoApiPassword + "@" + documentDBFQDN + ":" + mongoPort + "/" + documentDBConString
 	collectionClients   = "clients"
 	collectionHeartbeat = "heartbeat"
 	collectionData      = "data"
@@ -43,11 +36,64 @@ var ClientCollection *mongo.Collection
 var HeartbeatCollection *mongo.Collection
 var DataCollection *mongo.Collection
 
+// getEnvWithDefault returns the value of an environment variable or a default value if not set
+func getEnvWithDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+// buildMongoURI constructs a MongoDB connection URI based on environment variables
+func buildMongoURI(env string) string {
+	// Get configuration from environment variables
+	host := getEnvWithDefault("MONGO_HOST", "")
+	port := getEnvWithDefault("MONGO_PORT", "27017")
+	username := getEnvWithDefault("MONGO_USERNAME", "api_user")
+	password := getEnvWithDefault("MONGO_PASSWORD", "")
+	database := getEnvWithDefault("MONGO_DATABASE", "api_db")
+
+	// Validate required fields
+	if host == "" {
+		log.Fatal("MONGO_HOST environment variable is required")
+	}
+	if password == "" {
+		log.Fatal("MONGO_PASSWORD environment variable is required")
+	}
+
+	// Build base URI
+	uri := fmt.Sprintf("mongodb://%s:%s@%s:%s/%s", username, password, host, port, database)
+
+	// Add TLS configuration for AWS DocumentDB
+	if strings.ToUpper(env) == "AWS" {
+		tlsCAFile := getEnvWithDefault("MONGO_TLS_CA_FILE", "/etc/ssl/certs/rds-combined-ca-bundle.pem")
+		// DocumentDB requires TLS with specific connection parameters
+		uri += "?tls=true&tlsCAFile=" + tlsCAFile + "&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+	} else {
+		// For on-prem, check if TLS is explicitly requested
+		if useTLS := getEnvWithDefault("MONGO_USE_TLS", "false"); strings.ToLower(useTLS) == "true" {
+			uri += "?tls=true"
+			if tlsCAFile := os.Getenv("MONGO_TLS_CA_FILE"); tlsCAFile != "" {
+				uri += "&tlsCAFile=" + tlsCAFile
+			}
+		}
+	}
+
+	return uri
+}
+
 // Connect to database for the correct environment
-func InitMongoDB(dbForEnv string) {
+func InitMongoDB(env string) {
 	var err error
+
+	// Build connection URI based on environment
+	uri := buildMongoURI(env)
+	// Log connection info without exposing password
+	log.Printf("Connecting to MongoDB (environment: %s)", env)
+
 	// Set MongoDB connection options
-	Client, err = mongo.Connect(context.TODO(), options.Client().ApplyURI(dbForEnv))
+	// TLS configuration is handled through URI parameters (tls=true&tlsCAFile=...)
+	Client, err = mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
 	if err != nil {
 		log.Fatal("MongoDB Connection Error:", err)
 	}
@@ -59,6 +105,7 @@ func InitMongoDB(dbForEnv string) {
 	}
 
 	// Set collections
+	databaseName := getEnvWithDefault("MONGO_DATABASE", "api_db")
 	db := Client.Database(databaseName)
 	ClientCollection = db.Collection(collectionClients)
 	HeartbeatCollection = db.Collection(collectionHeartbeat)

--- a/test/busybox.yaml
+++ b/test/busybox.yaml
@@ -10,3 +10,10 @@ spec:
       command: ["/bin/sh", "-c", "sleep 3600"]
       stdin: true
       tty: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,17 +1,59 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Local automation: MongoDB in Docker + mongoclient image runs setup_mongo.sh.
+# Requires Docker. CI-friendly (no TTY required).
+set -euo pipefail
 
-# This is what we want. Build a client to inject data
-# Start mongodb, add in our data using the mongoclient
-# Run a few api tests, then kill the server by running stop
-docker build -t mongoclient -f mongoclient.dockerfile .
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NET="${DOCKER_NETWORK:-reaperc2-test-net}"
+MONGO_CTR="${MONGO_CONTAINER:-reaperc2-test-mongo}"
 
-docker run --rm -it \
-    --name mongodb \
-    -p 27017:27017 \
-    -e MONGO_INITDB_ROOT_USERNAME=admin \
-    -e MONGO_INITDB_ROOT_PASSWORD=supersecretpasswordlol \
-    -d mongodb/mongodb-community-server:latest
+cleanup() {
+  if [[ "${KEEP_MONGO:-0}" == "1" ]]; then
+    echo "KEEP_MONGO=1: leaving ${MONGO_CTR} on network ${NET} (remove manually when done)."
+    return
+  fi
+  docker rm -f "${MONGO_CTR}" >/dev/null 2>&1 || true
+  if [[ "${KEEP_TEST_NETWORK:-0}" != "1" ]]; then
+    docker network rm "${NET}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
 
-docker run --rm -it mongoclient
+docker network inspect "${NET}" >/dev/null 2>&1 || docker network create "${NET}"
 
-docker container stop mongodb
+docker build -t mongoclient -f "${SCRIPT_DIR}/mongoclient.dockerfile" "${SCRIPT_DIR}"
+
+docker run --rm -d \
+  --name "${MONGO_CTR}" \
+  --network "${NET}" \
+  -p 27017:27017 \
+  -e MONGO_INITDB_ROOT_USERNAME="${MONGO_ADMIN_USER:-admin}" \
+  -e MONGO_INITDB_ROOT_PASSWORD="${MONGO_ADMIN_PASSWORD:-supersecretpasswordlol}" \
+  mongodb/mongodb-community-server:latest
+
+echo "Waiting for MongoDB to accept connections..."
+ready=0
+for _ in $(seq 1 60); do
+  if docker exec "${MONGO_CTR}" mongosh --quiet --eval "db.runCommand({ ping: 1 })" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+if [[ "${ready}" != "1" ]]; then
+  echo "MongoDB did not become ready in time." >&2
+  exit 1
+fi
+
+docker run --rm \
+  --network "${NET}" \
+  -e MONGO_HOST="${MONGO_CTR}" \
+  -e MONGO_PORT=27017 \
+  -e MONGO_ADMIN_USER="${MONGO_ADMIN_USER:-admin}" \
+  -e MONGO_ADMIN_PASSWORD="${MONGO_ADMIN_PASSWORD:-supersecretpasswordlol}" \
+  -e MONGO_API_USER="${MONGO_API_USER:-api_user}" \
+  -e MONGO_API_PASSWORD="${MONGO_API_PASSWORD:-api_mongoApiPassword}" \
+  -e IMPORT_DATA_JSON="${IMPORT_DATA_JSON:-1}" \
+  mongoclient
+
+echo "Mongo seed finished."

--- a/test/setup_mongo.sh
+++ b/test/setup_mongo.sh
@@ -1,19 +1,30 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-ADMINUSER="admin"
-ADMINPASSWORD="supersecretpasswordlol"
-APIUSER="api_user"
-APIUSERPASSWORD="api_mongoApiPassword"
-# MONGOIPADDR="172.17.0.2"
-MONGOIPADDR="mongodb-service.reaperc2-ns.svc.cluster.local"
-MONGOPORT="27017"
-MONGO_URI="mongodb://$ADMINUSER:$ADMINPASSWORD@$MONGOIPADDR:$MONGOPORT"
+ADMINUSER="${MONGO_ADMIN_USER:-admin}"
+ADMINPASSWORD="${MONGO_ADMIN_PASSWORD:-supersecretpasswordlol}"
+APIUSER="${MONGO_API_USER:-api_user}"
+APIUSERPASSWORD="${MONGO_API_PASSWORD:-api_mongoApiPassword}"
+
+# Override for local Docker (e.g. run_tests.sh) or in-cluster exec:
+#   MONGO_HOST=mongodb MONGO_PORT=27017 ./setup_mongo.sh
+MONGO_HOST="${MONGO_HOST:-mongodb-service.reaperc2-ns.svc.cluster.local}"
+MONGO_PORT="${MONGO_PORT:-27017}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_JSON="${DATA_JSON:-$SCRIPT_DIR/data.json}"
+# Set to 0 to skip optional mongoimport of data.json
+IMPORT_DATA_JSON="${IMPORT_DATA_JSON:-1}"
+DATA_JSON_COLLECTION="${DATA_JSON_COLLECTION:-seed_docs}"
+
+MONGO_URI="mongodb://${ADMINUSER}:${ADMINPASSWORD}@${MONGO_HOST}:${MONGO_PORT}"
 DB_API_NAME="api_db"
 DB_DATA_COLLECTION="data"
 COLLECTION_CLIENTS="clients"
 COLLECTION_HEARTBEAT="heartbeat"
 
-echo "Creating MongoDB database $DB_API_NAME and collections: $COLLECTION_CLIENTS, $COLLECTION_HEARTBEAT, and $COLLECTION_CLIENTS..."
+echo "Connecting to ${MONGO_HOST}:${MONGO_PORT}"
+echo "Creating MongoDB database $DB_API_NAME and collections: $COLLECTION_CLIENTS, $COLLECTION_HEARTBEAT, $DB_DATA_COLLECTION..."
 
 # Test data, DO NOT USE IN PROD
 # This will run as a test, containers will be killed and deleted on stop
@@ -81,7 +92,6 @@ db.$DB_DATA_COLLECTION.insertMany([
         "ClientId": "550e8400-e29b-41d4-a716-446655440000",
         "info": "Sample data for client 1",
         "user": "",
-        groups: "",
         "hostname": "",
         "ip_address": "",
         "groups": [],
@@ -91,7 +101,6 @@ db.$DB_DATA_COLLECTION.insertMany([
         "ClientId": "660e9400-e29b-41d4-a716-556655440111",
         "info": "Sample data for client 2",
         "user": "",
-        groups: "",
         "hostname": "",
         "ip_address": "",
         "groups": [],
@@ -115,9 +124,16 @@ db.createUser({
 print("✅ Created $APIUSER with access to $DB_API_NAME");
 EOF
 
-# Import JSON data
-#mongoimport --db "$DB_API_NAME" --collection data_json_as_collection --file data.json --jsonArray
-
+if [[ "${IMPORT_DATA_JSON}" == "1" ]] && [[ -f "${DATA_JSON}" ]]; then
+  echo "Importing ${DATA_JSON} -> ${DB_API_NAME}.${DATA_JSON_COLLECTION}"
+  mongoimport \
+    --uri="${MONGO_URI}/${DB_API_NAME}?authSource=admin" \
+    --collection="${DATA_JSON_COLLECTION}" \
+    --file="${DATA_JSON}" \
+    --jsonArray
+else
+  echo "Skipping data.json import (IMPORT_DATA_JSON=${IMPORT_DATA_JSON} or missing file)."
+fi
 
 echo "MongoDB setup complete!"
 


### PR DESCRIPTION
…ment docs

MongoDB connection
- Remove hardcoded URIs from pkg/dbconnections; build URI from MONGO_HOST, MONGO_PORT, MONGO_USERNAME, MONGO_PASSWORD, MONGO_DATABASE.
- Apply DocumentDB TLS query params when DEPLOY_ENV/AWS path uses AWS; optional MONGO_USE_TLS and MONGO_TLS_CA_FILE for other environments.
- Require MONGO_HOST and MONGO_PASSWORD at runtime.

Application entrypoint
- Pass deploy environment string into InitMongoDB (not prebuilt URI constants).
- Fix log typo: Unknown Environment.

Kubernetes
- AWS full-deployment: Opaque secret template for Mongo credentials; wire deployment env (DEPLOY_ENV, MONGO_*, MONGO_TLS_CA_FILE) from secret.
- OnPrem full-deployment: set DEPLOY_ENV and MONGO_* from existing secrets and cluster Mongo service DNS.

Documentation
- Root README: document test/run_tests.sh, setup_mongo.sh env vars, local server env, remove obsolete Docker IP / mongoconnections edit instructions.
- DigitalOcean: expand Terraform README (resources, outputs, kubeconfig, ReaperC2 follow-up).

Test tooling
- run_tests.sh: Docker network, health wait, non-interactive mongoclient, configurable env, KEEP_MONGO/KEEP_TEST_NETWORK cleanup trap.
- setup_mongo.sh: MONGO_HOST/PORT and credential env overrides, mongoimport of data.json to seed_docs, fix invalid BSON in data insertMany.
- busybox.yaml: low CPU/memory requests and limits.

Made-with: Cursor