### PR TITLE
Audit beacon command delivery and output; include command_output in r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ Open `https://<host>:8443/beacons` (or `http://` locally; `/` redirects to **Bea
 | Area | Purpose |
 |------|---------|
 | **Beacons** | Generate clients (optional label, `ParentClientId` for pivot chain, optional pivot proxy for Scythe). Each generation **always saves a profile** in `beacon_profiles` (custom name or auto `beacon-xxxxxxxx-YYYYMMDD-hhmmss`). List/delete saved profiles. |
-| **Reports** | Download JSON or CSV exports (redacted or full) for briefings. |
+| **Reports** | Download JSON or CSV exports (redacted or full). JSON includes `command_output` (recent beacon command results from the `data` collection). |
 | **Topology** | Graph of C2 → beacons (and parent → child when `ParentClientId` is set on a client). |
 | **Chat** | Operator messages stored in `operator_chat`. |
 | **Users** (admins only) | Create additional portal accounts and assign **Admin** or **Operator** (`/users`, `POST /api/users`). |
-| **Logs** (admins only) | View recent **audit** events (`audit_logs` in MongoDB) and **download JSON** (`/api/logs/export`, `/logs`). |
+| **Logs** (admins only) | View recent **audit** events (`audit_logs`): operator actions plus **beacon** deliveries (`beacon_commands_delivered`) and **output** (`beacon_output_received`). Download JSON (`/api/logs/export`, `/logs`). |
 
 **Roles** (field `operators.role` in MongoDB): **Admin** — full portal access including user management. **Operator** — beacons, reports, topology, chat, and profile management; **cannot** create users or call user APIs. Accounts without `role` are treated as **Admin** for backward compatibility. The bootstrap account is always **Admin**.
 

--- a/pkg/adminpanel/handlers_logs.go
+++ b/pkg/adminpanel/handlers_logs.go
@@ -33,8 +33,8 @@ func (s *Server) handleLogsPage(w http.ResponseWriter, r *http.Request) {
 		if e.Details != nil {
 			b, _ := json.Marshal(e.Details)
 			detail = string(b)
-			if len(detail) > 120 {
-				detail = detail[:120] + "…"
+			if len(detail) > 360 {
+				detail = detail[:360] + "…"
 			}
 		}
 		tbl.WriteString("<tr><td>")
@@ -53,7 +53,7 @@ func (s *Server) handleLogsPage(w http.ResponseWriter, r *http.Request) {
 
 	body := `
 <h1>Audit logs</h1>
-<p class="muted">Portal events (beacon generation, report exports, user creation, profile deletes, etc.). Admins only.</p>
+<p class="muted">Portal and <strong>beacon</strong> events: queued commands, commands delivered on heartbeat, command output received (<code>beacon</code> actor), report exports, user creation, profile deletes, etc. Details may truncate in the table; use JSON export for full text. Admins only.</p>
 <div class="card">
   <p><a href="/api/logs/export" download="reaperc2-audit-log.json"><strong>Download full audit log (JSON)</strong></a> — up to 50k newest entries.</p>
 </div>

--- a/pkg/adminpanel/handlers_portal.go
+++ b/pkg/adminpanel/handlers_portal.go
@@ -228,8 +228,8 @@ func (s *Server) handleReportsPage(w http.ResponseWriter, r *http.Request) {
 <div class="card">
   <h2>Export</h2>
   <p><a href="/api/reports/export?format=json&redact=1" download>Download JSON (redacted)</a></p>
-  <p><a href="/api/reports/export?format=json" download>Download JSON (full)</a> — includes profile secrets; protect accordingly.</p>
-  <p><a href="/api/reports/export?format=csv&redact=1" download>Download CSV (redacted)</a></p>
+  <p><a href="/api/reports/export?format=json" download>Download JSON (full)</a> — includes profile secrets and beacon command output; protect accordingly. JSON includes <code>command_output</code> (newest 5000 rows from the data collection).</p>
+  <p><a href="/api/reports/export?format=csv&redact=1" download>Download CSV (redacted)</a> — clients table only; use JSON for command history.</p>
 </div>`
 	s.writeAppPage(w, user, role, "reports", "Reports", body)
 }
@@ -412,19 +412,29 @@ func (s *Server) handleAPIReportsExport(w http.ResponseWriter, r *http.Request) 
 	}
 	profiles, _ := dbconnections.ListBeaconProfiles(ctx, 500)
 	chat, _ := dbconnections.ListRecentChatMessages(ctx, 200)
+	cmdOut, errOut := dbconnections.ListRecentCommandOutputForExport(ctx, 5000)
+	if errOut != nil {
+		log.Printf("admin: report command output list: %v", errOut)
+		cmdOut = []dbconnections.CommandOutputRecord{}
+	}
+	if cmdOut == nil {
+		cmdOut = []dbconnections.CommandOutputRecord{}
+	}
 
 	type exportBundle struct {
-		GeneratedAt string                               `json:"generated_at"`
-		Clients     []dbconnections.BeaconClientDocument `json:"clients"`
-		Profiles    []dbconnections.BeaconProfile        `json:"profiles"`
-		Chat        []dbconnections.ChatMessage          `json:"operator_chat"`
+		GeneratedAt   string                               `json:"generated_at"`
+		Clients       []dbconnections.BeaconClientDocument `json:"clients"`
+		Profiles      []dbconnections.BeaconProfile        `json:"profiles"`
+		Chat          []dbconnections.ChatMessage          `json:"operator_chat"`
+		CommandOutput []dbconnections.CommandOutputRecord  `json:"command_output"`
 	}
 
 	bundle := exportBundle{
-		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
-		Clients:     clients,
-		Profiles:    profiles,
-		Chat:        chat,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Clients:       clients,
+		Profiles:      profiles,
+		Chat:          chat,
+		CommandOutput: cmdOut,
 	}
 	if redact {
 		for i := range bundle.Clients {
@@ -432,6 +442,9 @@ func (s *Server) handleAPIReportsExport(w http.ResponseWriter, r *http.Request) 
 		}
 		for i := range bundle.Profiles {
 			bundle.Profiles[i].Secret = "[REDACTED]"
+		}
+		for i := range bundle.CommandOutput {
+			bundle.CommandOutput[i].Output = "[REDACTED]"
 		}
 	}
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -162,6 +162,9 @@ func HandleHeartBeatUUID(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to retrieve commands", http.StatusInternalServerError)
 		return
 	}
+	if len(commands) > 0 {
+		auditBeaconCommandsDelivered(uuid, commands)
+	}
 
 	// Prepare response
 	response := map[string]interface{}{
@@ -241,6 +244,8 @@ func HandleReceiveUUID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditBeaconOutputReceived(clientUUID, requestData.Command, requestData.Output)
+
 	go func(id string) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -260,6 +265,39 @@ func HandleFourOhFour(w http.ResponseWriter, r *http.Request) {
 		"error":   "Not Found",
 		"message": "Endpoint not found.",
 	})
+}
+
+func auditBeaconCommandsDelivered(clientID string, commands []string) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+		if err := dbconnections.InsertAuditLog(ctx, "beacon", dbconnections.AuditActionBeaconCommandsDelivered, bson.M{
+			"client_id": clientID,
+			"commands":  commands,
+		}); err != nil {
+			log.Printf("audit beacon_commands_delivered: %v", err)
+		}
+	}()
+}
+
+func auditBeaconOutputReceived(clientID, command, output string) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+		const maxPreview = 2048
+		preview := output
+		if len(preview) > maxPreview {
+			preview = preview[:maxPreview] + "… [truncated]"
+		}
+		if err := dbconnections.InsertAuditLog(ctx, "beacon", dbconnections.AuditActionBeaconOutputReceived, bson.M{
+			"client_id":      clientID,
+			"command":        command,
+			"output_preview": preview,
+			"output_bytes":   len(output),
+		}); err != nil {
+			log.Printf("audit beacon_output_received: %v", err)
+		}
+	}()
 }
 
 // jsonResponse sends JSON data with the appropriate headers

--- a/pkg/dbconnections/audit.go
+++ b/pkg/dbconnections/audit.go
@@ -14,13 +14,15 @@ const collectionAuditLogs = "audit_logs"
 
 // Audit action names (portal audit trail).
 const (
-	AuditActionBeaconCreated       = "beacon_created"
-	AuditActionUserCreated         = "user_created"
-	AuditActionReportExported      = "report_exported"
-	AuditActionBeaconProfileDel    = "beacon_profile_deleted"
-	AuditActionAuditLogExported    = "audit_log_exported"
-	AuditActionBeaconCommandQueued = "beacon_command_queued"
-	AuditActionBeaconKillQueued    = "beacon_kill_queued"
+	AuditActionBeaconCreated           = "beacon_created"
+	AuditActionUserCreated             = "user_created"
+	AuditActionReportExported          = "report_exported"
+	AuditActionBeaconProfileDel        = "beacon_profile_deleted"
+	AuditActionAuditLogExported        = "audit_log_exported"
+	AuditActionBeaconCommandQueued     = "beacon_command_queued"
+	AuditActionBeaconKillQueued        = "beacon_kill_queued"
+	AuditActionBeaconCommandsDelivered = "beacon_commands_delivered"
+	AuditActionBeaconOutputReceived    = "beacon_output_received"
 )
 
 // AuditLogsCollection stores operator/C2 portal audit events.

--- a/pkg/dbconnections/mongoconnections.go
+++ b/pkg/dbconnections/mongoconnections.go
@@ -303,6 +303,31 @@ func ListCommandOutputForClient(ctx context.Context, clientID string, limit int6
 	return out, cur.Err()
 }
 
+// ListRecentCommandOutputForExport returns newest rows from the data collection (reports / briefings).
+func ListRecentCommandOutputForExport(ctx context.Context, limit int64) ([]CommandOutputRecord, error) {
+	if limit < 1 || limit > 20000 {
+		limit = 5000
+	}
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+	cur, err := DataCollection.Find(ctx, bson.M{}, options.Find().
+		SetSort(bson.D{{Key: "Timestamp", Value: -1}}).
+		SetLimit(limit))
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+	var out []CommandOutputRecord
+	for cur.Next(ctx) {
+		var rec CommandOutputRecord
+		if err := cur.Decode(&rec); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, cur.Err()
+}
+
 // BeaconClientExists reports whether a clients document exists for ClientId.
 func BeaconClientExists(ctx context.Context, clientID string) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)


### PR DESCRIPTION
…eport JSON

- Log beacon_commands_delivered (commands returned on GET /heartbeat/{uuid}) and beacon_output_received (POST /receive with command, output preview, size) to audit_logs with actor beacon.
- Add ListRecentCommandOutputForExport for report bundles; JSON export includes command_output (newest 5000 rows); redact output when redact=1.
- Widen audit log detail preview on /logs; document Reports and Logs in README.

Made-with: Cursor