### PR TITLE
feat(admin): TOTP, account security, engagements, and user admin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
+	github.com/pquerna/otp v1.5.0
 	go.mongodb.org/mongo-driver v1.17.3
 	golang.org/x/crypto v0.28.0
 )
 
 require (
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
@@ -14,6 +17,13 @@ github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGC
 github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=

--- a/pkg/adminpanel/engagement_ctx.go
+++ b/pkg/adminpanel/engagement_ctx.go
@@ -105,7 +105,8 @@ func engagementBannerFragment(eng *dbconnections.Engagement) string {
 	if !dbconnections.EngagementIsOpen(eng) {
 		closed = ` <span class="eng-closed-pill" title="Marked closed on Engagements page">Closed</span>`
 	}
-	return `<div class="engagement-bar">` + closed + `<span class="muted">Engagement</span> · <strong>` + name + `</strong> · <span class="muted">` + client + `</span> · <a href="/engagements">Switch engagement</a></div>`
+	haul := template.HTMLEscapeString(dbconnections.EngagementHaulTypeLabel(eng.HaulType))
+	return `<div class="engagement-bar">` + closed + `<span class="muted">Engagement</span> · <strong>` + name + `</strong> · <span class="muted">` + client + `</span> · <span class="muted">` + haul + `</span> · <a href="/engagements">Switch engagement</a></div>`
 }
 
 func engagementScriptFragment(eng *dbconnections.Engagement) string {

--- a/pkg/adminpanel/ghostwriter_export.go
+++ b/pkg/adminpanel/ghostwriter_export.go
@@ -240,6 +240,12 @@ func ghostwriterUserContext(action string) string {
 		return "Operator | audit log exported"
 	case dbconnections.AuditActionUserCreated:
 		return "Admin | user created"
+	case dbconnections.AuditActionUserDisabled:
+		return "Admin | user disabled"
+	case dbconnections.AuditActionUserEnabled:
+		return "Admin | user enabled"
+	case dbconnections.AuditActionEngagementOperatorsUpdated:
+		return "Admin | engagement operators updated"
 	default:
 		return "ReaperC2 | " + action
 	}
@@ -328,8 +334,37 @@ func WriteGhostwriterCSV(w io.Writer, audits []dbconnections.AuditLogEntry, data
 	return cw.Error()
 }
 
+func engagementReportGhostwriterRow(eng *dbconnections.Engagement, snapshotAt time.Time) ghostwriterSortRow {
+	ht := dbconnections.NormalizeEngagementHaulType(eng.HaulType)
+	label := dbconnections.EngagementHaulTypeLabel(ht)
+	ts := snapshotAt.UTC().Format(time.RFC3339)
+	meta, _ := json.Marshal(map[string]interface{}{
+		"engagement_id":   eng.ID.Hex(),
+		"haul_type":       ht,
+		"haul_type_label": label,
+	})
+	desc := fmt.Sprintf("Engagement | name=%s | client=%s | haul_type=%s (%s)", eng.Name, eng.ClientName, ht, label)
+	row := []string{
+		"engagement-" + eng.ID.Hex(),
+		ts,
+		ts,
+		ghostwriterC2EndpointName,
+		ghostwriterC2EndpointName,
+		"ReaperC2",
+		"Reports | engagement context",
+		"",
+		desc,
+		"",
+		string(meta),
+		"",
+		"reaperc2,reports,engagement," + ht,
+	}
+	return ghostwriterSortRow{t: snapshotAt.Add(time.Second), row: row}
+}
+
 // WriteReportsGhostwriterCSV writes the same 13-column Ghostwriter schema from report snapshot data (clients, profiles, command output) without audit or operator chat.
-func WriteReportsGhostwriterCSV(w io.Writer, clients []dbconnections.BeaconClientDocument, profiles []dbconnections.BeaconProfile, cmdOut []dbconnections.CommandOutputRecord, snapshotAt time.Time, redact bool) error {
+// If eng is non-nil, a first row documents the engagement (including haul type) so it appears in Ghostwriter imports.
+func WriteReportsGhostwriterCSV(w io.Writer, eng *dbconnections.Engagement, clients []dbconnections.BeaconClientDocument, profiles []dbconnections.BeaconProfile, cmdOut []dbconnections.CommandOutputRecord, snapshotAt time.Time, redact bool) error {
 	cw := csv.NewWriter(w)
 	if err := cw.Write(ghostwriterCSVHeader); err != nil {
 		return err
@@ -338,6 +373,9 @@ func WriteReportsGhostwriterCSV(w io.Writer, clients []dbconnections.BeaconClien
 	labelBy := beaconLabelsFromClients(clients)
 
 	var rows []ghostwriterSortRow
+	if eng != nil {
+		rows = append(rows, engagementReportGhostwriterRow(eng, snapshotAt))
+	}
 	rows = append(rows, ghostwriterRowsFromCommandOutput(cmdOut, labelBy)...)
 
 	for _, c := range clients {

--- a/pkg/adminpanel/handlers.go
+++ b/pkg/adminpanel/handlers.go
@@ -62,7 +62,12 @@ func (s *Server) handleLoginPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/engagements", http.StatusSeeOther)
 		return
 	}
-	writeHTML(w, http.StatusOK, loginPage, map[string]string{})
+	errMsg := ""
+	switch r.URL.Query().Get("err") {
+	case "mfa_expired":
+		errMsg = "Your two-factor step expired. Sign in again."
+	}
+	writeHTML(w, http.StatusOK, loginPage, map[string]string{"Error": errMsg})
 }
 
 func (s *Server) handleLoginPost(w http.ResponseWriter, r *http.Request) {
@@ -81,6 +86,34 @@ func (s *Server) handleLoginPost(w http.ResponseWriter, r *http.Request) {
 	op, err := dbconnections.FindOperatorByUsername(ctx, user)
 	if err != nil || !VerifyOperatorPassword(op.PasswordHash, pass) {
 		writeHTML(w, http.StatusOK, loginPage, map[string]string{"Error": "Invalid username or password."})
+		return
+	}
+	if dbconnections.OperatorIsDisabled(op) {
+		writeHTML(w, http.StatusOK, loginPage, map[string]string{"Error": "This account has been disabled."})
+		return
+	}
+	if op.TotpEnabled && strings.TrimSpace(op.TotpSecret) != "" {
+		mfaTok, err := newSessionToken()
+		if err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		exp := time.Now().UTC().Add(10 * time.Minute)
+		if err := dbconnections.InsertMFAChallenge(ctx, mfaTok, op.Username, exp); err != nil {
+			log.Printf("admin: mfa challenge insert: %v", err)
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:     mfaCookieName,
+			Value:    mfaTok,
+			Path:     "/",
+			MaxAge:   mfaCookieMaxAge,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   adminCookieSecure(),
+		})
+		http.Redirect(w, r, "/login/mfa", http.StatusSeeOther)
 		return
 	}
 	token, err := newSessionToken()
@@ -120,8 +153,14 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 		_ = dbconnections.DeleteSession(ctx, c.Value)
 	}
+	if c, err := r.Cookie(mfaCookieName); err == nil && c.Value != "" {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+		_ = dbconnections.DeleteMFAChallenge(ctx, c.Value)
+	}
 	clearEngagementCookie(w)
 	http.SetCookie(w, &http.Cookie{Name: cookieName, Value: "", Path: "/", MaxAge: -1})
+	s.clearMFACookie(w)
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }
 

--- a/pkg/adminpanel/handlers_account.go
+++ b/pkg/adminpanel/handlers_account.go
@@ -1,0 +1,588 @@
+package adminpanel
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"html/template"
+	"image/png"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"ReaperC2/pkg/dbconnections"
+
+	"github.com/pquerna/otp/totp"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func totpIssuer() string {
+	if v := strings.TrimSpace(os.Getenv("ADMIN_TOTP_ISSUER")); v != "" {
+		return v
+	}
+	return "ReaperC2"
+}
+
+// mfaPendingUsername returns the username if the MFA login cookie matches a non-expired challenge.
+func (s *Server) mfaPendingUsername(r *http.Request) (string, bool) {
+	c, err := r.Cookie(mfaCookieName)
+	if err != nil || c.Value == "" {
+		return "", false
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+	defer cancel()
+	u, err := dbconnections.PeekMFAChallenge(ctx, c.Value)
+	if err != nil || u == "" {
+		return "", false
+	}
+	return u, true
+}
+
+func (s *Server) clearMFACookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     mfaCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   adminCookieSecure(),
+	})
+}
+
+func (s *Server) handleLoginMFAPage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if _, _, ok := s.sessionUser(r); ok {
+		http.Redirect(w, r, "/engagements", http.StatusSeeOther)
+		return
+	}
+	c, err := r.Cookie(mfaCookieName)
+	if err != nil || c.Value == "" {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+	defer cancel()
+	if _, err := dbconnections.PeekMFAChallenge(ctx, c.Value); err != nil {
+		s.clearMFACookie(w)
+		http.Redirect(w, r, "/login?err=mfa_expired", http.StatusSeeOther)
+		return
+	}
+	errMsg := ""
+	if r.URL.Query().Get("err") == "bad_code" {
+		errMsg = "Invalid code. Try again."
+	}
+	writeHTML(w, http.StatusOK, mfaLoginPage, map[string]string{"Error": errMsg})
+}
+
+func (s *Server) handleLoginMFAPost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+	c, err := r.Cookie(mfaCookieName)
+	if err != nil || c.Value == "" {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	code := strings.TrimSpace(strings.ReplaceAll(r.FormValue("code"), " ", ""))
+	ctx, cancel := context.WithTimeout(r.Context(), 12*time.Second)
+	defer cancel()
+	username, err := dbconnections.PeekMFAChallenge(ctx, c.Value)
+	if err != nil {
+		s.clearMFACookie(w)
+		http.Redirect(w, r, "/login?err=mfa_expired", http.StatusSeeOther)
+		return
+	}
+	op, err := dbconnections.FindOperatorByUsername(ctx, username)
+	if err != nil || dbconnections.OperatorIsDisabled(op) || !op.TotpEnabled || strings.TrimSpace(op.TotpSecret) == "" {
+		s.clearMFACookie(w)
+		_ = dbconnections.DeleteMFAChallenge(ctx, c.Value)
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	if len(code) < 6 || !totp.Validate(code, op.TotpSecret) {
+		http.Redirect(w, r, "/login/mfa?err=bad_code", http.StatusSeeOther)
+		return
+	}
+	if err := dbconnections.DeleteMFAChallenge(ctx, c.Value); err != nil {
+		log.Printf("admin: delete mfa challenge: %v", err)
+	}
+	s.clearMFACookie(w)
+
+	token, err := newSessionToken()
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	sess := dbconnections.OperatorSession{
+		Token:     token,
+		Username:  op.Username,
+		ExpiresAt: time.Now().UTC().Add(sessionTTL()),
+	}
+	if err := dbconnections.InsertSession(ctx, sess); err != nil {
+		log.Printf("admin: session insert after mfa: %v", err)
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     cookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   cookieMaxAge,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   adminCookieSecure(),
+	})
+	http.Redirect(w, r, "/engagements", http.StatusSeeOther)
+}
+
+var mfaLoginPage = template.Must(template.New("mfa").Parse(`<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ReaperC2 Admin — Two-factor</title>
+<style>
+body{font-family:system-ui,sans-serif;background:#0f1419;color:#e6edf3;margin:0;padding:2rem;line-height:1.5}
+.card{max-width:24rem;margin:2rem auto;background:#161b22;border:1px solid #30363d;border-radius:8px;padding:1.5rem}
+h1{font-size:1.25rem;margin-top:0}
+label{display:block;margin-top:1rem;color:#8b949e;font-size:.875rem}
+input{width:100%;box-sizing:border-box;margin-top:.35rem;padding:.5rem .65rem;border-radius:6px;border:1px solid #30363d;background:#0d1117;color:#e6edf3;letter-spacing:.25em;font-size:1.1rem}
+button{cursor:pointer;width:100%;margin-top:1.25rem;padding:.6rem;border-radius:6px;border:1px solid #2ea043;background:#238636;color:#fff;font-weight:600}
+.err{color:#f85149;margin-top:.75rem;font-size:.9rem}
+.muted{color:#8b949e;font-size:.875rem}
+</style></head><body><div class="card">
+<h1>Authenticator code</h1>
+<p class="muted">Enter the 6-digit code from Google Authenticator (or another TOTP app).</p>
+{{if .Error}}<p class="err">{{.Error}}</p>{{end}}
+<form method="post" action="/login/mfa">
+<label>Code</label><input name="code" inputmode="numeric" pattern="[0-9 ]*" autocomplete="one-time-code" required autofocus>
+<button type="submit">Continue</button>
+</form>
+<p class="muted" style="margin-top:1rem"><a href="/login" style="color:#58a6ff">Start over</a></p>
+</div></body></html>`))
+
+func (s *Server) handleAccountPage(w http.ResponseWriter, r *http.Request) {
+	user, role, ok := s.requireHTMLAuth(w, r)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	op, err := dbconnections.FindOperatorByUsername(ctx, user)
+	if err != nil {
+		http.Error(w, "failed to load account", http.StatusInternalServerError)
+		return
+	}
+	totpOn := op.TotpEnabled && strings.TrimSpace(op.TotpSecret) != ""
+	pending := strings.TrimSpace(op.TotpPendingSecret) != ""
+	body := `
+<h1>Account</h1>
+<p class="muted">Change your password anytime. Set up two-factor authentication (TOTP) with Google Authenticator or any compatible app.</p>
+
+<div class="card">
+  <h2>Password</h2>
+  <label>Current password</label>
+  <input id="pw_cur" type="password" autocomplete="current-password">
+  <label>New password</label>
+  <input id="pw_new" type="password" autocomplete="new-password">
+  <p class="muted" style="margin-top:.5rem;font-size:.82rem">At least 10 characters.</p>
+  <button type="button" class="btn" id="pw_save">Update password</button>
+  <p id="pw_msg" class="muted" style="margin-top:.75rem;min-height:1.2rem"></p>
+</div>
+
+<div class="card">
+  <h2>Two-factor authentication (TOTP)</h2>
+  <p class="muted" id="totp_status">` + template.HTMLEscapeString(totpStatusLine(totpOn, pending)) + `</p>
+  <div id="totp_setup" style="display:none;margin-top:1rem">
+    <p class="muted">Scan the QR code in Google Authenticator, or enter the secret manually.</p>
+    <div id="totp_qr_wrap" style="margin:.75rem 0"></div>
+    <p class="mono" id="totp_secret_line" style="display:none;font-size:.8rem"></p>
+    <label>6-digit code from the app</label>
+    <input id="totp_code" inputmode="numeric" maxlength="10" autocomplete="one-time-code" placeholder="000000">
+    <button type="button" class="btn" id="totp_verify">Verify and enable</button>
+    <button type="button" class="btn btn-secondary" id="totp_cancel">Cancel setup</button>
+  </div>
+  <div style="margin-top:.75rem;display:flex;flex-wrap:wrap;gap:.5rem;align-items:center">
+    <button type="button" class="btn btn-secondary" id="totp_begin" ` + totpBeginDisabled(totpOn) + `>Set up authenticator</button>
+    <button type="button" class="btn btn-kill" id="totp_disable" ` + totpDisableDisabled(!totpOn) + `>Disable 2FA</button>
+  </div>
+  <p id="totp_msg" class="muted" style="margin-top:.75rem;min-height:1.2rem"></p>
+  <dialog id="totp_disable_dlg" style="max-width:22rem;border:1px solid #30363d;border-radius:8px;background:#161b22;color:#e6edf3;padding:1.25rem">
+    <p>Enter your current password to disable two-factor authentication.</p>
+    <label>Password</label>
+    <input id="totp_disable_pw" type="password" autocomplete="current-password">
+    <div style="margin-top:.75rem;display:flex;gap:.5rem;flex-wrap:wrap">
+      <button type="button" class="btn btn-kill" id="totp_disable_confirm">Disable</button>
+      <button type="button" class="btn btn-secondary" id="totp_disable_close">Cancel</button>
+    </div>
+  </dialog>
+</div>
+<script>
+(function() {
+  function show(el, msg, isErr) {
+    el.textContent = msg || '';
+    el.style.color = isErr ? '#f85149' : 'var(--muted)';
+  }
+  var pwMsg = document.getElementById('pw_msg');
+  document.getElementById('pw_save').onclick = async function() {
+    show(pwMsg, '…', false);
+    var body = {
+      current_password: document.getElementById('pw_cur').value,
+      new_password: document.getElementById('pw_new').value
+    };
+    var r = await fetch('/api/account/password', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    var j = await r.json().catch(function() { return {}; });
+    if (r.ok) {
+      show(pwMsg, 'Password updated.', false);
+      document.getElementById('pw_cur').value = '';
+      document.getElementById('pw_new').value = '';
+    } else {
+      show(pwMsg, j.error || r.statusText, true);
+    }
+  };
+
+  var totpMsg = document.getElementById('totp_msg');
+  var totpSetup = document.getElementById('totp_setup');
+  var totpStatus = document.getElementById('totp_status');
+  var qrWrap = document.getElementById('totp_qr_wrap');
+  var secLine = document.getElementById('totp_secret_line');
+
+  document.getElementById('totp_begin').onclick = async function() {
+    show(totpMsg, '…', false);
+    var r = await fetch('/api/account/totp/begin', { method: 'POST', credentials: 'same-origin' });
+    var j = await r.json().catch(function() { return {}; });
+    if (!r.ok) { show(totpMsg, j.error || r.statusText, true); return; }
+    totpSetup.style.display = 'block';
+    qrWrap.innerHTML = '';
+    if (j.qr_png_base64) {
+      var img = document.createElement('img');
+      img.src = 'data:image/png;base64,' + j.qr_png_base64;
+      img.alt = 'QR';
+      img.width = 200;
+      img.height = 200;
+      qrWrap.appendChild(img);
+    }
+    if (j.secret_base32) {
+      secLine.style.display = 'block';
+      secLine.textContent = 'Secret (manual entry): ' + j.secret_base32;
+    }
+    totpStatus.textContent = 'Finish by entering a code from the app.';
+    show(totpMsg, '', false);
+  };
+  document.getElementById('totp_cancel').onclick = async function() {
+    await fetch('/api/account/totp/cancel', { method: 'POST', credentials: 'same-origin' });
+    totpSetup.style.display = 'none';
+    location.reload();
+  };
+  document.getElementById('totp_verify').onclick = async function() {
+    show(totpMsg, '…', false);
+    var code = (document.getElementById('totp_code').value || '').replace(/\s+/g, '');
+    var r = await fetch('/api/account/totp/verify', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ code: code }) });
+    var j = await r.json().catch(function() { return {}; });
+    if (r.ok) {
+      location.reload();
+    } else {
+      show(totpMsg, j.error || r.statusText, true);
+    }
+  };
+  var dlg = document.getElementById('totp_disable_dlg');
+  document.getElementById('totp_disable').onclick = function() {
+    document.getElementById('totp_disable_pw').value = '';
+    if (dlg.showModal) dlg.showModal(); else alert('Use a browser that supports dialogs.');
+  };
+  document.getElementById('totp_disable_close').onclick = function() { if (dlg.close) dlg.close(); };
+  document.getElementById('totp_disable_confirm').onclick = async function() {
+    var r = await fetch('/api/account/totp/disable', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ password: document.getElementById('totp_disable_pw').value }) });
+    var j = await r.json().catch(function() { return {}; });
+    if (r.ok) {
+      if (dlg.close) dlg.close();
+      location.reload();
+    } else {
+      alert(j.error || r.statusText);
+    }
+  };
+})();
+</script>`
+	s.writeAppPage(w, user, role, "account", "Account", body, nil)
+}
+
+func totpStatusLine(enabled, pending bool) string {
+	switch {
+	case enabled:
+		return "Two-factor authentication is on."
+	case pending:
+		return "Setup started — finish verification below or cancel."
+	default:
+		return "Two-factor authentication is off."
+	}
+}
+
+func totpBeginDisabled(already bool) string {
+	if already {
+		return `disabled style="opacity:0.5"`
+	}
+	return ""
+}
+
+func totpDisableDisabled(off bool) string {
+	if off {
+		return `disabled style="opacity:0.5"`
+	}
+	return ""
+}
+
+func (s *Server) handleAPIAccountGET(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user, _, ok := s.sessionUser(r)
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+	defer cancel()
+	op, err := dbconnections.FindOperatorByUsername(ctx, user)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed")
+		return
+	}
+	totpOn := op.TotpEnabled && strings.TrimSpace(op.TotpSecret) != ""
+	pending := strings.TrimSpace(op.TotpPendingSecret) != ""
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"username":       op.Username,
+		"totp_enabled":   totpOn,
+		"totp_pending":   pending,
+	})
+}
+
+type accountPasswordRequest struct {
+	CurrentPassword string `json:"current_password"`
+	NewPassword     string `json:"new_password"`
+}
+
+func (s *Server) handleAPIAccountPasswordPOST(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user, _, ok := s.sessionUser(r)
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var req accountPasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if len(req.NewPassword) < 10 {
+		jsonError(w, http.StatusBadRequest, "new password must be at least 10 characters")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	op, err := dbconnections.FindOperatorByUsername(ctx, user)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed")
+		return
+	}
+	if !VerifyOperatorPassword(op.PasswordHash, req.CurrentPassword) {
+		jsonError(w, http.StatusUnauthorized, "current password incorrect")
+		return
+	}
+	hash, err := HashOperatorPassword(req.NewPassword)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "hash error")
+		return
+	}
+	if err := dbconnections.UpdateOperatorPasswordHash(ctx, user, hash); err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed to update password")
+		return
+	}
+	_ = dbconnections.DeleteMFAChallengesForUser(ctx, user)
+	if aerr := dbconnections.InsertAuditLog(ctx, user, dbconnections.AuditActionPasswordChanged, bson.M{}, ""); aerr != nil {
+		log.Printf("admin: audit password: %v", aerr)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+}
+
+func (s *Server) handleAPIAccountTotpBegin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user, _, ok := s.sessionUser(r)
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	op, err := dbconnections.FindOperatorByUsername(ctx, user)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed")
+		return
+	}
+	if op.TotpEnabled && strings.TrimSpace(op.TotpSecret) != "" {
+		jsonError(w, http.StatusBadRequest, "two-factor is already enabled; disable it first to re-enroll")
+		return
+	}
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      totpIssuer(),
+		AccountName: op.Username,
+	})
+	if err != nil {
+		log.Printf("admin: totp generate: %v", err)
+		jsonError(w, http.StatusInternalServerError, "failed to generate secret")
+		return
+	}
+	secret := key.Secret()
+	if err := dbconnections.SetOperatorTotpPending(ctx, user, secret); err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed to save pending secret")
+		return
+	}
+	img, err := key.Image(200, 200)
+	if err != nil {
+		log.Printf("admin: totp qr image: %v", err)
+		jsonError(w, http.StatusInternalServerError, "failed to build qr")
+		return
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed to encode qr")
+		return
+	}
+	b64 := base64.StdEncoding.EncodeToString(buf.Bytes())
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"secret_base32": secret,
+		"qr_png_base64": b64,
+	})
+}
+
+type totpVerifyRequest struct {
+	Code string `json:"code"`
+}
+
+func (s *Server) handleAPIAccountTotpVerify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user, _, ok := s.sessionUser(r)
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var req totpVerifyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	code := strings.TrimSpace(strings.ReplaceAll(req.Code, " ", ""))
+	if len(code) < 6 {
+		jsonError(w, http.StatusBadRequest, "invalid code")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	op, err := dbconnections.FindOperatorByUsername(ctx, user)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed")
+		return
+	}
+	pending := strings.TrimSpace(op.TotpPendingSecret)
+	if pending == "" {
+		jsonError(w, http.StatusBadRequest, "no enrollment in progress; start setup again")
+		return
+	}
+	if !totp.Validate(code, pending) {
+		jsonError(w, http.StatusBadRequest, "code does not match; check the clock on your phone")
+		return
+	}
+	if err := dbconnections.ConfirmOperatorTotp(ctx, user); err != nil {
+		if err == mongo.ErrNoDocuments {
+			jsonError(w, http.StatusBadRequest, "enrollment out of date; start again")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "failed to enable 2fa")
+		return
+	}
+	if aerr := dbconnections.InsertAuditLog(ctx, user, dbconnections.AuditActionTotpEnabled, bson.M{}, ""); aerr != nil {
+		log.Printf("admin: audit totp: %v", aerr)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+}
+
+type totpDisableRequest struct {
+	Password string `json:"password"`
+}
+
+func (s *Server) handleAPIAccountTotpDisable(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user, _, ok := s.sessionUser(r)
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var req totpDisableRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	op, err := dbconnections.FindOperatorByUsername(ctx, user)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed")
+		return
+	}
+	if !VerifyOperatorPassword(op.PasswordHash, req.Password) {
+		jsonError(w, http.StatusUnauthorized, "password incorrect")
+		return
+	}
+	if err := dbconnections.DisableOperatorTotp(ctx, user); err != nil {
+		jsonError(w, http.StatusInternalServerError, "failed to disable 2fa")
+		return
+	}
+	if aerr := dbconnections.InsertAuditLog(ctx, user, dbconnections.AuditActionTotpDisabled, bson.M{}, ""); aerr != nil {
+		log.Printf("admin: audit totp disable: %v", aerr)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+}
+
+func (s *Server) handleAPIAccountTotpCancel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user, _, ok := s.sessionUser(r)
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+	defer cancel()
+	_ = dbconnections.ClearOperatorTotpPending(ctx, user)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+}

--- a/pkg/adminpanel/handlers_engagements.go
+++ b/pkg/adminpanel/handlers_engagements.go
@@ -13,6 +13,7 @@ import (
 	"ReaperC2/pkg/dbconnections"
 
 	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -36,6 +37,23 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("admin: list operators for engagement form: %v", err)
 		ops = nil
+	}
+	isAdminUser := role == dbconnections.RoleAdmin
+	type opBrief struct {
+		Username string `json:"username"`
+		Role     string `json:"role"`
+		Disabled bool   `json:"disabled"`
+	}
+	var opsMeta []opBrief
+	for _, o := range ops {
+		if o.Username == "" {
+			continue
+		}
+		opsMeta = append(opsMeta, opBrief{Username: o.Username, Role: o.Role, Disabled: o.Disabled})
+	}
+	opsMetaJSON, err := json.Marshal(opsMeta)
+	if err != nil {
+		opsMetaJSON = []byte("[]")
 	}
 	var rows strings.Builder
 	for _, e := range list {
@@ -63,6 +81,9 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
 		rows.WriteString(`">`)
 		rows.WriteString(template.HTMLEscapeString(stLabel))
 		rows.WriteString(`</span></td><td>`)
+		ht := dbconnections.NormalizeEngagementHaulType(e.HaulType)
+		rows.WriteString(template.HTMLEscapeString(dbconnections.EngagementHaulTypeLabel(ht)))
+		rows.WriteString(`</td><td>`)
 		rows.WriteString(template.HTMLEscapeString(strings.Join(e.AssignedOperators, ", ")))
 		rows.WriteString(`</td><td style="white-space:nowrap"><button type="button" class="btn btn-secondary btn-tiny" data-open="`)
 		rows.WriteString(template.HTMLEscapeString(id))
@@ -71,11 +92,11 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
 		rows.WriteString(`">Manage</button></td></tr>`)
 	}
 	if rows.Len() == 0 {
-		rows.WriteString(`<tr><td colspan="7" class="muted">No engagements yet — create one below.</td></tr>`)
+		rows.WriteString(`<tr><td colspan="8" class="muted">No engagements yet — create one below.</td></tr>`)
 	}
 	var opChecks strings.Builder
 	for _, o := range ops {
-		if o.Username == "" {
+		if o.Username == "" || dbconnections.OperatorIsDisabled(&o) {
 			continue
 		}
 		opChecks.WriteString(`<label style="display:block;margin:.35rem 0"><input type="checkbox" name="op" value="`)
@@ -91,10 +112,10 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	body := `
 <h1>Engagements</h1>
-<p class="muted">Each engagement scopes <strong>Beacons</strong>, <strong>Commands</strong>, <strong>Reports</strong>, <strong>Topology</strong>, and <strong>Chat</strong>. Use <strong>Workspace</strong> to select it for operator pages. <strong>Manage</strong> sets open/closed and notes (shown in the banner when closed).</p>
+<p class="muted">Each engagement scopes <strong>Beacons</strong>, <strong>Commands</strong>, <strong>Reports</strong>, <strong>Topology</strong>, and <strong>Chat</strong>. Use <strong>Workspace</strong> to select it for operator pages. <strong>Manage</strong> sets status, haul type, notes, and (for administrators) <strong>assigned operators</strong>. Closed engagements show a banner pill.</p>
 <div class="card">
   <h2>Your engagements</h2>
-  <table><thead><tr><th>Name</th><th>Client</th><th>Start</th><th>End</th><th>Status</th><th>Operators</th><th></th></tr></thead><tbody>` + rows.String() + `</tbody></table>
+  <table><thead><tr><th>Name</th><th>Client</th><th>Start</th><th>End</th><th>Status</th><th>Haul</th><th>Operators</th><th></th></tr></thead><tbody>` + rows.String() + `</tbody></table>
 </div>
 <dialog id="engManageDlg" class="eng-manage-dialog">
   <h2>Manage engagement</h2>
@@ -104,9 +125,20 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
     <option value="open">Open</option>
     <option value="closed">Closed</option>
   </select>
+  <label for="engDlgHaul">Haul type</label>
+  <select id="engDlgHaul">
+    <option value="interactive">Interactive</option>
+    <option value="short_haul">Short Haul</option>
+    <option value="long_haul">Long Haul</option>
+  </select>
   <label for="engDlgNotes">Notes</label>
   <p class="muted" style="font-size:.82rem;margin:.35rem 0 0">Internal reminders, scope, handoff — not shown to beacons.</p>
   <textarea id="engDlgNotes" placeholder="e.g. pivot rules, reporting window, customer contacts…"></textarea>
+  <div id="engDlgOpsSection" style="display:none;margin-top:.75rem">
+    <label>Assigned operators</label>
+    <p class="muted" style="font-size:.82rem;margin:.25rem 0 .35rem">Administrators only: choose which operators can open this workspace. Admins always have access.</p>
+    <div id="engDlgOpChecks" style="margin-top:.35rem"></div>
+  </div>
   <p id="engDlgMsg" class="cmd-inline-msg muted"></p>
   <div class="dlg-actions">
     <button type="button" class="btn" id="engDlgSave">Save</button>
@@ -123,6 +155,13 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
   <input id="enStart" type="date">
   <label>End date</label>
   <input id="enEnd" type="date">
+  <label>Haul type</label>
+  <select id="enHaul">
+    <option value="interactive">Interactive</option>
+    <option value="short_haul">Short Haul</option>
+    <option value="long_haul">Long Haul</option>
+  </select>
+  <p class="muted" style="font-size:.82rem;margin:.25rem 0 0">Used for engagement planning and included in report exports.</p>
   <label>Slack / Discord room name</label>
   <input id="enRoom" placeholder="e.g. #acme-2026-ops — used as chat room key">
   <label>Notes (optional)</label>
@@ -138,8 +177,41 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
 .eng-st-closed { color: #8b949e; font-weight: 600; font-size: .85rem; }
 </style>
 <script>
+window.__REAPER_IS_ADMIN__ = ` + map[bool]string{true: "true", false: "false"}[isAdminUser] + `;
+window.ENG_OPS_META = ` + string(opsMetaJSON) + `;
 var engDlgId = null;
 var dlg = document.getElementById('engManageDlg');
+function buildEngDlgOps(j) {
+  var sec = document.getElementById('engDlgOpsSection');
+  var box = document.getElementById('engDlgOpChecks');
+  if (!box || !sec) return;
+  box.innerHTML = '';
+  if (!window.__REAPER_IS_ADMIN__) { sec.style.display = 'none'; return; }
+  sec.style.display = 'block';
+  var assigned = {};
+  if (j.assigned_operators && j.assigned_operators.length) {
+    j.assigned_operators.forEach(function(u) { assigned[u] = true; });
+  }
+  (window.ENG_OPS_META || []).forEach(function(op) {
+    if (op.disabled) return;
+    var lab = document.createElement('label');
+    lab.style.display = 'block';
+    lab.style.margin = '.35rem 0';
+    var inp = document.createElement('input');
+    inp.type = 'checkbox';
+    inp.value = op.username;
+    if (assigned[op.username]) inp.checked = true;
+    lab.appendChild(inp);
+    lab.appendChild(document.createTextNode(' ' + op.username));
+    if (op.role) {
+      var sp = document.createElement('span');
+      sp.className = 'muted';
+      sp.textContent = ' (' + op.role + ')';
+      lab.appendChild(sp);
+    }
+    box.appendChild(lab);
+  });
+}
 document.querySelectorAll('[data-open]').forEach(function(btn) {
   btn.onclick = async function() {
     var id = btn.getAttribute('data-open');
@@ -157,7 +229,11 @@ document.querySelectorAll('[data-manage]').forEach(function(btn) {
     if (!r.ok) { alert((j && j.error) ? j.error : r.statusText); return; }
     document.getElementById('engDlgSubtitle').textContent = (j.name || '') + ' · ' + (j.client_name || '');
     document.getElementById('engDlgStatus').value = (j.status === 'closed') ? 'closed' : 'open';
+    var haul = j.haul_type || 'interactive';
+    if (haul !== 'short_haul' && haul !== 'long_haul') haul = 'interactive';
+    document.getElementById('engDlgHaul').value = haul;
     document.getElementById('engDlgNotes').value = j.notes || '';
+    buildEngDlgOps(j);
     if (dlg.showModal) dlg.showModal(); else dlg.setAttribute('open', '');
   };
 });
@@ -168,8 +244,14 @@ document.getElementById('engDlgSave').onclick = async function() {
   msg.textContent = 'Saving…';
   var body = {
     status: document.getElementById('engDlgStatus').value,
+    haul_type: document.getElementById('engDlgHaul').value,
     notes: document.getElementById('engDlgNotes').value
   };
+  if (window.__REAPER_IS_ADMIN__) {
+    var aops = [];
+    document.querySelectorAll('#engDlgOpChecks input[type=checkbox]:checked').forEach(function(c) { aops.push(c.value); });
+    body.assigned_operators = aops;
+  }
   var r = await fetch('/api/engagements/' + encodeURIComponent(engDlgId), {
     method: 'PATCH',
     credentials: 'same-origin',
@@ -196,7 +278,7 @@ document.getElementById('enCreate').onclick = async function() {
   var ops = [];
   document.querySelectorAll('#opChecks input[type=checkbox]:checked').forEach(function(c) { ops.push(c.value); });
   el.textContent = 'Saving…';
-  var r = await fetch('/api/engagements', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: name, client_name: client, start_date: sd, end_date: ed, slack_discord_room: room, assigned_operators: ops, notes: notes }) });
+  var r = await fetch('/api/engagements', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: name, client_name: client, start_date: sd, end_date: ed, haul_type: document.getElementById('enHaul').value, slack_discord_room: room, assigned_operators: ops, notes: notes }) });
   var j = await r.json().catch(function() { return {}; });
   if (r.ok && j.id) {
     el.textContent = 'Created. Opening…';
@@ -215,6 +297,7 @@ type createEngagementAPI struct {
 	ClientName        string   `json:"client_name"`
 	StartDate         string   `json:"start_date"`
 	EndDate           string   `json:"end_date"`
+	HaulType          string   `json:"haul_type"`
 	SlackDiscordRoom  string   `json:"slack_discord_room"`
 	AssignedOperators []string `json:"assigned_operators"`
 	Notes             string   `json:"notes"`
@@ -295,11 +378,17 @@ func (s *Server) handleAPIEngagementsCreate(w http.ResponseWriter, r *http.Reque
 			assign = append(assign, user)
 		}
 	}
+	assign = dbconnections.NormalizeAssignedOperatorList(assign)
+	if err := dbconnections.ValidateAssignedOperatorUsernames(ctx, assign); err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	id, err := dbconnections.InsertEngagement(ctx, dbconnections.Engagement{
 		Name:              req.Name,
 		ClientName:        req.ClientName,
 		StartDate:         start,
 		EndDate:           end,
+		HaulType:          dbconnections.NormalizeEngagementHaulType(req.HaulType),
 		SlackDiscordRoom:  strings.TrimSpace(req.SlackDiscordRoom),
 		AssignedOperators: assign,
 		CreatedBy:         user,
@@ -336,6 +425,7 @@ func (s *Server) handleAPIEngagementsGET(w http.ResponseWriter, r *http.Request)
 		SlackDiscordRoom  string   `json:"slack_discord_room,omitempty"`
 		AssignedOperators []string `json:"assigned_operators"`
 		Status            string   `json:"status"`
+		HaulType          string   `json:"haul_type"`
 	}
 	var out []row
 	for _, e := range list {
@@ -343,6 +433,7 @@ func (s *Server) handleAPIEngagementsGET(w http.ResponseWriter, r *http.Request)
 		if st == "" {
 			st = dbconnections.EngagementStatusOpen
 		}
+		ht := dbconnections.NormalizeEngagementHaulType(e.HaulType)
 		out = append(out, row{
 			ID:                e.ID.Hex(),
 			Name:              e.Name,
@@ -352,6 +443,7 @@ func (s *Server) handleAPIEngagementsGET(w http.ResponseWriter, r *http.Request)
 			SlackDiscordRoom:  e.SlackDiscordRoom,
 			AssignedOperators: e.AssignedOperators,
 			Status:            st,
+			HaulType:          ht,
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -401,6 +493,7 @@ func engagementAPIMap(e *dbconnections.Engagement) map[string]interface{} {
 	if st == "" {
 		st = dbconnections.EngagementStatusOpen
 	}
+	ht := dbconnections.NormalizeEngagementHaulType(e.HaulType)
 	return map[string]interface{}{
 		"id":                 e.ID.Hex(),
 		"name":               e.Name,
@@ -410,6 +503,8 @@ func engagementAPIMap(e *dbconnections.Engagement) map[string]interface{} {
 		"slack_discord_room": e.SlackDiscordRoom,
 		"assigned_operators": e.AssignedOperators,
 		"status":             st,
+		"haul_type":          ht,
+		"haul_type_label":    dbconnections.EngagementHaulTypeLabel(ht),
 		"notes":              e.Notes,
 		"created_at":         e.CreatedAt.UTC().Format(time.RFC3339),
 		"created_by":         e.CreatedBy,
@@ -452,8 +547,10 @@ func (s *Server) handleAPIEngagementByID(w http.ResponseWriter, r *http.Request)
 		_ = json.NewEncoder(w).Encode(engagementAPIMap(e))
 	case http.MethodPatch:
 		var req struct {
-			Status *string `json:"status"`
-			Notes  *string `json:"notes"`
+			Status              *string   `json:"status"`
+			Notes               *string   `json:"notes"`
+			HaulType            *string   `json:"haul_type"`
+			AssignedOperators   *[]string `json:"assigned_operators"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			jsonError(w, http.StatusBadRequest, "invalid json")
@@ -471,7 +568,18 @@ func (s *Server) handleAPIEngagementByID(w http.ResponseWriter, r *http.Request)
 			}
 			patch.Notes = req.Notes
 		}
-		if patch.Status == nil && patch.Notes == nil {
+		if req.HaulType != nil {
+			h := strings.TrimSpace(*req.HaulType)
+			patch.HaulType = &h
+		}
+		if req.AssignedOperators != nil {
+			if !isAdmin(role) {
+				jsonError(w, http.StatusForbidden, "only administrators can change assigned operators")
+				return
+			}
+			patch.AssignedOperators = req.AssignedOperators
+		}
+		if patch.Status == nil && patch.Notes == nil && patch.HaulType == nil && patch.AssignedOperators == nil {
 			jsonError(w, http.StatusBadRequest, "no changes")
 			return
 		}
@@ -480,13 +588,22 @@ func (s *Server) handleAPIEngagementByID(w http.ResponseWriter, r *http.Request)
 				jsonError(w, http.StatusNotFound, "engagement not found")
 				return
 			}
-			if strings.Contains(err.Error(), "invalid engagement status") {
+			if strings.Contains(err.Error(), "invalid engagement status") || strings.Contains(err.Error(), "invalid haul_type") ||
+				strings.Contains(err.Error(), "unknown operator") || strings.Contains(err.Error(), "is disabled") {
 				jsonError(w, http.StatusBadRequest, err.Error())
 				return
 			}
 			log.Printf("admin: update engagement %s: %v", idHex, err)
 			jsonError(w, http.StatusInternalServerError, "failed to update")
 			return
+		}
+		if req.AssignedOperators != nil && isAdmin(role) {
+			if aerr := dbconnections.InsertAuditLog(ctx, user, dbconnections.AuditActionEngagementOperatorsUpdated, bson.M{
+				"engagement_id": idHex,
+				"operators":     *req.AssignedOperators,
+			}, idHex); aerr != nil {
+				log.Printf("admin: audit engagement ops: %v", aerr)
+			}
 		}
 		e2, err := dbconnections.FindEngagementByID(ctx, idHex)
 		if err != nil {

--- a/pkg/adminpanel/handlers_portal.go
+++ b/pkg/adminpanel/handlers_portal.go
@@ -28,11 +28,15 @@ func (s *Server) writeAppPage(w http.ResponseWriter, user, role, active, title, 
 
 func (s *Server) requireHTMLAuth(w http.ResponseWriter, r *http.Request) (string, string, bool) {
 	u, role, ok := s.sessionUser(r)
-	if !ok {
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
+	if ok {
+		return u, role, true
+	}
+	if _, mfaOK := s.mfaPendingUsername(r); mfaOK && r.URL.Path != "/login/mfa" {
+		http.Redirect(w, r, "/login/mfa", http.StatusSeeOther)
 		return "", "", false
 	}
-	return u, role, true
+	http.Redirect(w, r, "/login", http.StatusSeeOther)
+	return "", "", false
 }
 
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
@@ -384,7 +388,7 @@ func (s *Server) handleReportsPage(w http.ResponseWriter, r *http.Request) {
 <div class="card">
   <h2>Export</h2>
   <p><a href="/api/reports/export?format=json&redact=1" download>Download JSON (redacted)</a></p>
-  <p><a href="/api/reports/export?format=json" download>Download JSON (full)</a> — includes profile secrets and beacon command output; protect accordingly. JSON includes <code>command_output</code> (newest 5000 rows from the data collection). Operator chat is under <strong>Logs</strong> exports, not here.</p>
+  <p><a href="/api/reports/export?format=json" download>Download JSON (full)</a> — includes an <code>engagement</code> block (name, dates, <strong>haul type</strong>), profile secrets, and beacon command output; protect accordingly. JSON includes <code>command_output</code> (newest 5000 rows from the data collection). Operator chat is under <strong>Logs</strong> exports, not here.</p>
   <p><a href="/api/reports/export?format=csv&redact=1" download>Download CSV (redacted)</a> — clients table only; use JSON for command history.</p>
   <p><a href="/api/reports/export-ghostwriter?redact=1" download>Ghostwriter CSV (redacted)</a></p>
   <p><a href="/api/reports/export-ghostwriter" download>Ghostwriter CSV (full)</a> — same 13-column Specter Ops schema as Logs: clients, saved profiles, and beacon command output (newest first).</p>
@@ -590,15 +594,36 @@ func (s *Server) handleAPIReportsExport(w http.ResponseWriter, r *http.Request) 
 		cmdOut = []dbconnections.CommandOutputRecord{}
 	}
 
+	type engagementExportSnapshot struct {
+		ID               string `json:"id"`
+		Name             string `json:"name"`
+		ClientName       string `json:"client_name"`
+		StartDate        string `json:"start_date"`
+		EndDate          string `json:"end_date"`
+		HaulType         string `json:"haul_type"`
+		HaulTypeLabel    string `json:"haul_type_label"`
+		SlackDiscordRoom string `json:"slack_discord_room,omitempty"`
+	}
 	type exportBundle struct {
 		GeneratedAt   string                               `json:"generated_at"`
+		Engagement    engagementExportSnapshot             `json:"engagement"`
 		Clients       []dbconnections.BeaconClientDocument `json:"clients"`
 		Profiles      []dbconnections.BeaconProfile        `json:"profiles"`
 		CommandOutput []dbconnections.CommandOutputRecord  `json:"command_output"`
 	}
-
+	ht := dbconnections.NormalizeEngagementHaulType(eng.HaulType)
 	bundle := exportBundle{
-		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Engagement: engagementExportSnapshot{
+			ID:               eng.ID.Hex(),
+			Name:             eng.Name,
+			ClientName:       eng.ClientName,
+			StartDate:        eng.StartDate.UTC().Format(time.RFC3339),
+			EndDate:          eng.EndDate.UTC().Format(time.RFC3339),
+			HaulType:         ht,
+			HaulTypeLabel:    dbconnections.EngagementHaulTypeLabel(ht),
+			SlackDiscordRoom: eng.SlackDiscordRoom,
+		},
 		Clients:       clients,
 		Profiles:      profiles,
 		CommandOutput: cmdOut,
@@ -624,7 +649,9 @@ func (s *Server) handleAPIReportsExport(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Type", "text/csv")
 		w.Header().Set("Content-Disposition", `attachment; filename="reaperc2-clients.csv"`)
 		cw := csv.NewWriter(w)
-		_ = cw.Write([]string{"ClientId", "Active", "Connection_Type", "ParentClientId", "BeaconLabel", "Secret"})
+		eh := dbconnections.NormalizeEngagementHaulType(eng.HaulType)
+		el := dbconnections.EngagementHaulTypeLabel(eh)
+		_ = cw.Write([]string{"ClientId", "Active", "Connection_Type", "ParentClientId", "BeaconLabel", "Secret", "EngagementName", "EngagementHaulType", "EngagementHaulLabel"})
 		for _, c := range clients {
 			sec := c.Secret
 			if redact {
@@ -637,6 +664,9 @@ func (s *Server) handleAPIReportsExport(w http.ResponseWriter, r *http.Request) 
 				c.ParentClientId,
 				c.BeaconLabel,
 				sec,
+				eng.Name,
+				eh,
+				el,
 			})
 		}
 		cw.Flush()
@@ -680,7 +710,7 @@ func (s *Server) handleAPIReportsExportGhostwriter(w http.ResponseWriter, r *htt
 
 	snapshotAt := time.Now().UTC()
 	var buf bytes.Buffer
-	if err := WriteReportsGhostwriterCSV(&buf, clients, profiles, cmdOut, snapshotAt, redact); err != nil {
+	if err := WriteReportsGhostwriterCSV(&buf, eng, clients, profiles, cmdOut, snapshotAt, redact); err != nil {
 		log.Printf("admin: WriteReportsGhostwriterCSV: %v", err)
 		jsonError(w, http.StatusInternalServerError, "export failed")
 		return

--- a/pkg/adminpanel/handlers_users.go
+++ b/pkg/adminpanel/handlers_users.go
@@ -3,6 +3,7 @@ package adminpanel
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"html/template"
 	"log"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 
 	"ReaperC2/pkg/dbconnections"
 
+	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -58,21 +60,42 @@ func (s *Server) handleUsersPage(w http.ResponseWriter, r *http.Request) {
 	var rows strings.Builder
 	for _, op := range ops {
 		rn := effectivePortalRole(&op)
+		st := "Active"
+		if dbconnections.OperatorIsDisabled(&op) {
+			st = "Disabled"
+		}
 		rows.WriteString("<tr><td>")
 		rows.WriteString(template.HTMLEscapeString(op.Username))
 		rows.WriteString("</td><td>")
 		rows.WriteString(template.HTMLEscapeString(rn))
 		rows.WriteString("</td><td>")
+		rows.WriteString(template.HTMLEscapeString(st))
+		rows.WriteString("</td><td>")
 		rows.WriteString(template.HTMLEscapeString(op.CreatedAt.UTC().Format(time.RFC3339)))
+		rows.WriteString(`</td><td style="white-space:nowrap">`)
+		if op.Username != u {
+			if dbconnections.OperatorIsDisabled(&op) {
+				rows.WriteString(`<button type="button" class="btn btn-secondary btn-tiny" data-enable="`)
+				rows.WriteString(template.HTMLEscapeString(op.Username))
+				rows.WriteString(`">Enable</button>`)
+			} else {
+				rows.WriteString(`<button type="button" class="btn btn-kill btn-tiny" data-disable="`)
+				rows.WriteString(template.HTMLEscapeString(op.Username))
+				rows.WriteString(`">Disable</button>`)
+			}
+		} else {
+			rows.WriteString(`<span class="muted">—</span>`)
+		}
 		rows.WriteString("</td></tr>")
 	}
 	if rows.Len() == 0 {
-		rows.WriteString("<tr><td colspan=\"3\" class=\"muted\">No users.</td></tr>")
+		rows.WriteString("<tr><td colspan=\"5\" class=\"muted\">No users.</td></tr>")
 	}
 
+	selfQuoted, _ := json.Marshal(u)
 	body := `
 <h1>Users</h1>
-<p class="muted">Create portal accounts. <strong>Admin</strong> may manage users and <strong>All logs</strong>; <strong>Operator</strong> may use beacons, commands, reports, topology, chat, and <strong>Engagement logs</strong> for the selected engagement.</p>
+<p class="muted">Create portal accounts. <strong>Disabled</strong> users cannot sign in; their sessions end immediately. You cannot disable yourself. <strong>Admin</strong> may manage users and <strong>All logs</strong>; <strong>Operator</strong> may use beacons, commands, reports, topology, chat, and <strong>Engagement logs</strong> for the selected engagement.</p>
 <div class="card">
   <h2>Create user</h2>
   <label>Username</label>
@@ -91,9 +114,10 @@ func (s *Server) handleUsersPage(w http.ResponseWriter, r *http.Request) {
 </div>
 <div class="card">
   <h2>Accounts</h2>
-  <table><thead><tr><th>Username</th><th>Role</th><th>Created</th></tr></thead><tbody>` + rows.String() + `</tbody></table>
+  <table><thead><tr><th>Username</th><th>Role</th><th>Status</th><th>Created</th><th></th></tr></thead><tbody>` + rows.String() + `</tbody></table>
 </div>
 <script>
+window.__USERS_SELF__ = ` + string(selfQuoted) + `;
 document.getElementById('createu').onclick = async function() {
   var out = document.getElementById('uout');
   out.style.display = 'block';
@@ -107,6 +131,32 @@ document.getElementById('createu').onclick = async function() {
   out.textContent = r.ok ? JSON.stringify(j, null, 2) : (j.error || r.statusText);
 };
 document.getElementById('refusers').onclick = function() { location.reload(); };
+async function patchUser(username, disabled) {
+  var r = await fetch('/api/users/' + encodeURIComponent(username), {
+    method: 'PATCH',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ disabled: disabled })
+  });
+  var j = await r.json().catch(function() { return {}; });
+  if (!r.ok) { alert(j.error || r.statusText); return; }
+  location.reload();
+}
+document.querySelectorAll('[data-disable]').forEach(function(btn) {
+  btn.onclick = function() {
+    var name = btn.getAttribute('data-disable');
+    if (!name || name === window.__USERS_SELF__) return;
+    if (!confirm('Disable ' + name + '? They will be signed out and cannot log in until re-enabled.')) return;
+    patchUser(name, true);
+  };
+});
+document.querySelectorAll('[data-enable]').forEach(function(btn) {
+  btn.onclick = function() {
+    var name = btn.getAttribute('data-enable');
+    if (!name) return;
+    patchUser(name, false);
+  };
+});
 </script>`
 	s.writeAppPage(w, u, role, "users", "Users", body, nil)
 }
@@ -180,6 +230,78 @@ func (s *Server) handleAPICreateUser(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "username": req.Username, "role": role})
 }
 
+func (s *Server) handleAPIUserByUsername(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPatch {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	adminUser, ok := s.requireAdminAPI(w, r)
+	if !ok {
+		return
+	}
+	target := strings.TrimSpace(mux.Vars(r)["username"])
+	if target == "" {
+		jsonError(w, http.StatusBadRequest, "username required")
+		return
+	}
+	if strings.EqualFold(target, adminUser) {
+		jsonError(w, http.StatusBadRequest, "cannot change your own account here")
+		return
+	}
+	var req struct {
+		Disabled *bool `json:"disabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if req.Disabled == nil {
+		jsonError(w, http.StatusBadRequest, "no changes")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+	targetOp, err := dbconnections.FindOperatorByUsername(ctx, target)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			jsonError(w, http.StatusNotFound, "user not found")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "lookup failed")
+		return
+	}
+	if *req.Disabled && isAdmin(effectivePortalRole(targetOp)) {
+		n, err := dbconnections.CountActiveAdminsExcluding(ctx, target)
+		if err != nil {
+			log.Printf("admin: count active admins: %v", err)
+			jsonError(w, http.StatusInternalServerError, "failed")
+			return
+		}
+		if n == 0 {
+			jsonError(w, http.StatusBadRequest, "cannot disable the last active administrator")
+			return
+		}
+	}
+	if err := dbconnections.SetOperatorDisabled(ctx, target, *req.Disabled); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			jsonError(w, http.StatusNotFound, "user not found")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "failed to update user")
+		return
+	}
+	_ = dbconnections.DeleteSessionsForUsername(ctx, target)
+	_ = dbconnections.DeleteMFAChallengesForUser(ctx, target)
+	action := dbconnections.AuditActionUserEnabled
+	if *req.Disabled {
+		action = dbconnections.AuditActionUserDisabled
+	}
+	if aerr := dbconnections.InsertAuditLog(ctx, adminUser, action, bson.M{"target_username": target}, ""); aerr != nil {
+		log.Printf("admin: audit user enable/disable: %v", aerr)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "username": target, "disabled": *req.Disabled})
+}
 
 func isValidUsername(s string) bool {
 	for _, r := range s {

--- a/pkg/adminpanel/panel.go
+++ b/pkg/adminpanel/panel.go
@@ -19,6 +19,9 @@ const (
 	cookieName     = "reaperc2_admin_session"
 	cookieMaxAge   = 86400 * 7 // 7 days (browser hint; real expiry is server-side)
 	sessionIDBytes = 32
+
+	mfaCookieName   = "reaperc2_admin_mfa"
+	mfaCookieMaxAge = 600 // 10 minutes (must match MFA challenge TTL)
 )
 
 func sessionTTL() time.Duration {

--- a/pkg/adminpanel/server.go
+++ b/pkg/adminpanel/server.go
@@ -22,7 +22,17 @@ func NewServer() *Server {
 	s.router.HandleFunc("/health", s.handleHealth).Methods(http.MethodGet)
 	s.router.HandleFunc("/login", s.handleLoginPage).Methods(http.MethodGet)
 	s.router.HandleFunc("/login", s.handleLoginPost).Methods(http.MethodPost)
+	s.router.HandleFunc("/login/mfa", s.handleLoginMFAPage).Methods(http.MethodGet)
+	s.router.HandleFunc("/login/mfa", s.handleLoginMFAPost).Methods(http.MethodPost)
 	s.router.HandleFunc("/logout", s.handleLogout).Methods(http.MethodPost)
+
+	s.router.HandleFunc("/account", s.handleAccountPage).Methods(http.MethodGet)
+	s.router.HandleFunc("/api/account", s.handleAPIAccountGET).Methods(http.MethodGet)
+	s.router.HandleFunc("/api/account/password", s.handleAPIAccountPasswordPOST).Methods(http.MethodPost)
+	s.router.HandleFunc("/api/account/totp/begin", s.handleAPIAccountTotpBegin).Methods(http.MethodPost)
+	s.router.HandleFunc("/api/account/totp/verify", s.handleAPIAccountTotpVerify).Methods(http.MethodPost)
+	s.router.HandleFunc("/api/account/totp/disable", s.handleAPIAccountTotpDisable).Methods(http.MethodPost)
+	s.router.HandleFunc("/api/account/totp/cancel", s.handleAPIAccountTotpCancel).Methods(http.MethodPost)
 
 	s.router.HandleFunc("/engagements", s.handleEngagementsPage).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/engagements", s.handleAPIEngagements).Methods(http.MethodGet, http.MethodPost)
@@ -45,6 +55,7 @@ func NewServer() *Server {
 	s.router.HandleFunc("/api/beacon-artifacts/{id}", s.handleAPIBeaconArtifactDelete).Methods(http.MethodDelete)
 	s.router.HandleFunc("/api/beacon-command-output", s.handleAPIBeaconCommandOutput).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/beacon-kill", s.handleAPIBeaconKill).Methods(http.MethodPost)
+	s.router.HandleFunc("/api/users/{username}", s.handleAPIUserByUsername).Methods(http.MethodPatch)
 	s.router.HandleFunc("/api/users", s.handleAPICreateUser).Methods(http.MethodPost)
 	s.router.HandleFunc("/api/logs/export", s.handleAPIAuditExport).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/logs/export-ghostwriter", s.handleAPIAuditExportGhostwriter).Methods(http.MethodGet)
@@ -85,6 +96,10 @@ func (s *Server) sessionUser(r *http.Request) (username, role string, ok bool) {
 	}
 	op, err := dbconnections.FindOperatorByUsername(ctx, sess.Username)
 	if err != nil {
+		return "", "", false
+	}
+	if dbconnections.OperatorIsDisabled(op) {
+		_ = dbconnections.DeleteSession(ctx, c.Value)
 		return "", "", false
 	}
 	return op.Username, effectivePortalRole(op), true

--- a/pkg/adminpanel/ui.go
+++ b/pkg/adminpanel/ui.go
@@ -176,6 +176,7 @@ details.cmd-fold[open] summary::before { content: "▾ "; }
   <div class="brand">ReaperC2</div>
 ` + engagementBannerHTML + `
 ` + navItem("/engagements", "Engagements", active, "engagements") + `
+` + navItem("/account", "Account", active, "account") + `
 ` + navItem("/beacons", "Beacons", active, "beacons") + `
 ` + navItem("/commands", "Commands", active, "commands") + `
 ` + navItem("/reports", "Reports", active, "reports") + `

--- a/pkg/dbconnections/admin.go
+++ b/pkg/dbconnections/admin.go
@@ -34,6 +34,14 @@ type Operator struct {
 	PasswordHash string    `bson:"password_hash"`
 	Role         string    `bson:"role,omitempty"`
 	CreatedAt    time.Time `bson:"created_at"`
+	// TotpEnabled is true after the user completes TOTP enrollment (Google Authenticator, etc.).
+	TotpEnabled bool `bson:"totp_enabled,omitempty"`
+	// TotpSecret is the base32-encoded shared secret; empty when MFA is off.
+	TotpSecret string `bson:"totp_secret,omitempty"`
+	// TotpPendingSecret holds the next secret until the user confirms with a valid code.
+	TotpPendingSecret string `bson:"totp_pending_secret,omitempty"`
+	// Disabled if true: cannot sign in; existing sessions are invalidated when set.
+	Disabled bool `bson:"disabled,omitempty"`
 }
 
 // OperatorSession is a server-side session record (token is stored as _id).
@@ -75,6 +83,7 @@ func initAdminCollections(db *mongo.Database) {
 		Keys:    bson.D{{Key: "username", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	})
+	initMFAChallengesCollection(db)
 	initPortalCollections(db)
 	initAuditCollections(db)
 	initFileArtifactsCollection(db)
@@ -117,6 +126,8 @@ func ListOperators(ctx context.Context) ([]Operator, error) {
 			return nil, err
 		}
 		op.PasswordHash = ""
+		op.TotpSecret = ""
+		op.TotpPendingSecret = ""
 		out = append(out, op)
 	}
 	return out, cur.Err()
@@ -145,6 +156,169 @@ func FindSessionByToken(ctx context.Context, token string) (*OperatorSession, er
 // DeleteSession removes a session by token.
 func DeleteSession(ctx context.Context, token string) error {
 	_, err := OperatorSessionsCollection.DeleteOne(ctx, bson.M{"_id": token})
+	return err
+}
+
+// DeleteSessionsForUsername removes all sessions for an operator (e.g. after disable).
+func DeleteSessionsForUsername(ctx context.Context, username string) error {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	_, err := OperatorSessionsCollection.DeleteMany(ctx, bson.M{"username": username})
+	return err
+}
+
+// OperatorIsDisabled reports whether login should be rejected (legacy docs = active).
+func OperatorIsDisabled(op *Operator) bool {
+	return op != nil && op.Disabled
+}
+
+// CountActiveAdminsExcluding returns how many non-disabled admin accounts exist besides excludeUsername.
+func CountActiveAdminsExcluding(ctx context.Context, excludeUsername string) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	excludeUsername = strings.TrimSpace(excludeUsername)
+	cur, err := OperatorsCollection.Find(ctx, bson.M{}, options.Find().SetProjection(bson.M{"username": 1, "role": 1, "disabled": 1}))
+	if err != nil {
+		return 0, err
+	}
+	defer cur.Close(ctx)
+	n := 0
+	for cur.Next(ctx) {
+		var op Operator
+		if err := cur.Decode(&op); err != nil {
+			return 0, err
+		}
+		if strings.EqualFold(op.Username, excludeUsername) {
+			continue
+		}
+		if OperatorIsDisabled(&op) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(op.Role), RoleOperator) {
+			continue
+		}
+		n++
+	}
+	return n, cur.Err()
+}
+
+// SetOperatorDisabled sets disabled flag and returns mongo.ErrNoDocuments if user missing.
+func SetOperatorDisabled(ctx context.Context, username string, disabled bool) error {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return mongo.ErrNoDocuments
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	res, err := OperatorsCollection.UpdateOne(ctx, bson.M{"username": username}, bson.M{"$set": bson.M{"disabled": disabled}})
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+// UpdateOperatorPasswordHash sets a new password hash for an operator.
+func UpdateOperatorPasswordHash(ctx context.Context, username, passwordHash string) error {
+	username = strings.TrimSpace(username)
+	if username == "" || passwordHash == "" {
+		return mongo.ErrNoDocuments
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	res, err := OperatorsCollection.UpdateOne(ctx, bson.M{"username": username}, bson.M{"$set": bson.M{"password_hash": passwordHash}})
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+// SetOperatorTotpPending stores a base32 secret for enrollment (not yet active).
+func SetOperatorTotpPending(ctx context.Context, username, pendingSecretBase32 string) error {
+	username = strings.TrimSpace(username)
+	if username == "" || pendingSecretBase32 == "" {
+		return mongo.ErrNoDocuments
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	res, err := OperatorsCollection.UpdateOne(ctx, bson.M{"username": username}, bson.M{"$set": bson.M{"totp_pending_secret": pendingSecretBase32}})
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+// ConfirmOperatorTotp promotes totp_pending_secret to totp_secret and enables MFA.
+func ConfirmOperatorTotp(ctx context.Context, username string) error {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return mongo.ErrNoDocuments
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	var op Operator
+	err := OperatorsCollection.FindOne(ctx, bson.M{"username": username}).Decode(&op)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(op.TotpPendingSecret) == "" {
+		return mongo.ErrNoDocuments
+	}
+	_, err = OperatorsCollection.UpdateOne(ctx, bson.M{"username": username}, bson.M{
+		"$set": bson.M{
+			"totp_secret":  op.TotpPendingSecret,
+			"totp_enabled": true,
+		},
+		"$unset": bson.M{"totp_pending_secret": ""},
+	})
+	return err
+}
+
+// DisableOperatorTotp turns off MFA and clears secrets.
+func DisableOperatorTotp(ctx context.Context, username string) error {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return mongo.ErrNoDocuments
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	res, err := OperatorsCollection.UpdateOne(ctx, bson.M{"username": username}, bson.M{
+		"$set": bson.M{"totp_enabled": false},
+		"$unset": bson.M{
+			"totp_secret":         "",
+			"totp_pending_secret": "",
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+// ClearOperatorTotpPending abandons in-progress enrollment.
+func ClearOperatorTotpPending(ctx context.Context, username string) error {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return mongo.ErrNoDocuments
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	_, err := OperatorsCollection.UpdateOne(ctx, bson.M{"username": username}, bson.M{"$unset": bson.M{"totp_pending_secret": ""}})
 	return err
 }
 

--- a/pkg/dbconnections/audit.go
+++ b/pkg/dbconnections/audit.go
@@ -24,6 +24,12 @@ const (
 	AuditActionBeaconKillQueued        = "beacon_kill_queued"
 	AuditActionBeaconCommandsDelivered = "beacon_commands_delivered"
 	AuditActionBeaconOutputReceived    = "beacon_output_received"
+	AuditActionPasswordChanged         = "password_changed"
+	AuditActionTotpEnabled             = "totp_enabled"
+	AuditActionTotpDisabled            = "totp_disabled"
+	AuditActionUserDisabled              = "user_disabled"
+	AuditActionUserEnabled               = "user_enabled"
+	AuditActionEngagementOperatorsUpdated = "engagement_operators_updated"
 )
 
 // AuditLogsCollection stores operator/C2 portal audit events.

--- a/pkg/dbconnections/engagements.go
+++ b/pkg/dbconnections/engagements.go
@@ -18,6 +18,36 @@ const (
 	EngagementStatusClosed = "closed"
 )
 
+// EngagementHaulType categorizes the operation style (reporting / planning).
+const (
+	EngagementHaulInteractive = "interactive"
+	EngagementHaulShortHaul   = "short_haul"
+	EngagementHaulLongHaul    = "long_haul"
+)
+
+// NormalizeEngagementHaulType returns a valid haul key; empty or unknown defaults to interactive.
+func NormalizeEngagementHaulType(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	switch s {
+	case EngagementHaulShortHaul, EngagementHaulLongHaul, EngagementHaulInteractive:
+		return s
+	default:
+		return EngagementHaulInteractive
+	}
+}
+
+// EngagementHaulTypeLabel is a display name for reports and UI.
+func EngagementHaulTypeLabel(key string) string {
+	switch NormalizeEngagementHaulType(key) {
+	case EngagementHaulShortHaul:
+		return "Short Haul"
+	case EngagementHaulLongHaul:
+		return "Long Haul"
+	default:
+		return "Interactive"
+	}
+}
+
 const collectionEngagements = "engagements"
 
 // EngagementsCollection stores operator-facing engagement records.
@@ -50,6 +80,8 @@ type Engagement struct {
 	Status string `bson:"status,omitempty" json:"status,omitempty"`
 	// Notes is free-form operator text (scope, reminders, handoff).
 	Notes string `bson:"notes,omitempty" json:"notes,omitempty"`
+	// HaulType is interactive | short_haul | long_haul (planning / reporting category).
+	HaulType string `bson:"haul_type,omitempty" json:"haul_type,omitempty"`
 }
 
 // InsertEngagement stores a new engagement; creator is added to AssignedOperators if missing.
@@ -73,6 +105,7 @@ func InsertEngagement(ctx context.Context, e Engagement) (primitive.ObjectID, er
 	if strings.TrimSpace(e.Status) == "" {
 		e.Status = EngagementStatusOpen
 	}
+	e.HaulType = NormalizeEngagementHaulType(e.HaulType)
 	res, err := EngagementsCollection.InsertOne(ctx, e)
 	if err != nil {
 		return primitive.NilObjectID, err
@@ -110,6 +143,38 @@ func UserCanAccessEngagement(role, username string, e *Engagement) bool {
 	return false
 }
 
+// NormalizeAssignedOperatorList trims, deduplicates, and drops empty strings.
+func NormalizeAssignedOperatorList(usernames []string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, raw := range usernames {
+		u := strings.TrimSpace(raw)
+		if u == "" || seen[u] {
+			continue
+		}
+		seen[u] = true
+		out = append(out, u)
+	}
+	return out
+}
+
+// ValidateAssignedOperatorUsernames ensures each name exists and is not disabled.
+func ValidateAssignedOperatorUsernames(ctx context.Context, usernames []string) error {
+	for _, u := range usernames {
+		op, err := FindOperatorByUsername(ctx, u)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				return fmt.Errorf("unknown operator %q", u)
+			}
+			return err
+		}
+		if OperatorIsDisabled(op) {
+			return fmt.Errorf("operator %q is disabled", u)
+		}
+	}
+	return nil
+}
+
 // ListEngagementsForUser returns engagements visible to this portal user (newest first).
 func ListEngagementsForUser(ctx context.Context, role, username string) ([]Engagement, error) {
 	var filter bson.M
@@ -145,8 +210,10 @@ func EngagementIsOpen(e *Engagement) bool {
 
 // EngagementPatch is a partial update for engagements.
 type EngagementPatch struct {
-	Status *string // "open" | "closed", or nil to skip
-	Notes  *string // nil = skip; empty string clears notes
+	Status             *string   // "open" | "closed", or nil to skip
+	Notes              *string   // nil = skip; empty string clears notes
+	HaulType           *string   // nil = skip; validated when set
+	AssignedOperators  *[]string // nil = skip; replaces list; each user must exist and not be disabled
 }
 
 // UpdateEngagement applies non-nil patch fields. Validates status when set.
@@ -169,6 +236,20 @@ func UpdateEngagement(ctx context.Context, idHex string, patch EngagementPatch) 
 	}
 	if patch.Notes != nil {
 		set["notes"] = *patch.Notes
+	}
+	if patch.HaulType != nil {
+		h := strings.ToLower(strings.TrimSpace(*patch.HaulType))
+		if h != EngagementHaulInteractive && h != EngagementHaulShortHaul && h != EngagementHaulLongHaul {
+			return fmt.Errorf("invalid haul_type %q (use interactive, short_haul, or long_haul)", *patch.HaulType)
+		}
+		set["haul_type"] = h
+	}
+	if patch.AssignedOperators != nil {
+		norm := NormalizeAssignedOperatorList(*patch.AssignedOperators)
+		if err := ValidateAssignedOperatorUsernames(ctx, norm); err != nil {
+			return err
+		}
+		set["assigned_operators"] = norm
 	}
 	if len(set) == 0 {
 		return nil

--- a/pkg/dbconnections/mfa_challenge.go
+++ b/pkg/dbconnections/mfa_challenge.go
@@ -1,0 +1,82 @@
+package dbconnections
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const collectionMFAChallenges = "operator_mfa_challenges"
+
+// MFAChallengesCollection stores short-lived tokens between password check and TOTP entry at login.
+var MFAChallengesCollection *mongo.Collection
+
+// MFAChallenge is a pending second factor step after successful password verification.
+type MFAChallenge struct {
+	Token     string    `bson:"_id"`
+	Username  string    `bson:"username"`
+	ExpiresAt time.Time `bson:"expires_at"`
+}
+
+func initMFAChallengesCollection(db *mongo.Database) {
+	MFAChallengesCollection = db.Collection(collectionMFAChallenges)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	_, _ = MFAChallengesCollection.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "expires_at", Value: 1}},
+		Options: options.Index().SetExpireAfterSeconds(600), // 10 minutes; also enforced in code
+	})
+}
+
+// InsertMFAChallenge stores a challenge token for the given username.
+func InsertMFAChallenge(ctx context.Context, token, username string, expiresAt time.Time) error {
+	_, err := MFAChallengesCollection.InsertOne(ctx, MFAChallenge{
+		Token:     token,
+		Username:  username,
+		ExpiresAt: expiresAt,
+	})
+	return err
+}
+
+// DeleteMFAChallenge removes a challenge by token (after successful TOTP or abandon).
+func DeleteMFAChallenge(ctx context.Context, token string) error {
+	if token == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	_, err := MFAChallengesCollection.DeleteOne(ctx, bson.M{"_id": token})
+	return err
+}
+
+// PeekMFAChallenge returns the username if the token exists and is not expired (does not delete).
+func PeekMFAChallenge(ctx context.Context, token string) (username string, err error) {
+	if token == "" {
+		return "", mongo.ErrNoDocuments
+	}
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	var ch MFAChallenge
+	err = MFAChallengesCollection.FindOne(ctx, bson.M{
+		"_id":        token,
+		"expires_at": bson.M{"$gt": time.Now().UTC()},
+	}).Decode(&ch)
+	if err != nil {
+		return "", err
+	}
+	return ch.Username, nil
+}
+
+// DeleteMFAChallengesForUser removes any pending login challenges for a user (e.g. after password change).
+func DeleteMFAChallengesForUser(ctx context.Context, username string) error {
+	if username == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	_, err := MFAChallengesCollection.DeleteMany(ctx, bson.M{"username": username})
+	return err
+}


### PR DESCRIPTION
feat(admin): TOTP, account security, engagements, and user admin
    
    - Add Google Authenticator (TOTP) enrollment, MFA login step, and MFA
      challenge storage; Account page for password change and 2FA setup/disable.
    - Add engagement haul type (interactive / short haul / long haul) in setup,
      API, banner, and report exports (JSON, CSV, Ghostwriter).
    - Allow admins to disable or enable portal users (sessions cleared); protect
      last active admin; PATCH /api/users/{username}.
    - Allow admins to assign operators on engagements via Manage dialog and PATCH;
      validate operators and block disabled accounts from assignment.
    - Nav Account link; audit and Ghostwriter labels for new actions.
    
    third_party/Scythe submodule remains dirty and was not committed.
    
    Made-with: Cursor