### PR TITLE
Beacon embed: SOCKS5 listener options for Scythe HTTP

### DIFF
--- a/pkg/adminpanel/handlers.go
+++ b/pkg/adminpanel/handlers.go
@@ -174,6 +174,8 @@ type scytheHTTPInput struct {
 	Headers       string `json:"headers"`
 	Proxy         string `json:"proxy"`
 	SkipTLSVerify bool   `json:"skip_tls_verify"`
+	Socks5Listen  bool   `json:"socks5_listen"`
+	Socks5Port    int    `json:"socks5_port"`
 	Goos          string `json:"goos"`   // linux, windows, darwin
 	Goarch        string `json:"goarch"` // amd64, arm64
 }
@@ -274,6 +276,13 @@ func (s *Server) handleCreateBeacon(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusInternalServerError, "failed to create client")
 		return
 	}
+	if req.ScytheHTTP != nil && req.ScytheHTTP.Socks5Listen {
+		p := req.ScytheHTTP.Socks5Port
+		if p < 1 || p > 65535 {
+			jsonError(w, http.StatusBadRequest, "socks5_port must be between 1 and 65535 when socks5_listen is true")
+			return
+		}
+	}
 	base, err := ResolveBeaconBaseURL(req.BeaconBaseURL)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, err.Error())
@@ -316,6 +325,8 @@ func (s *Server) handleCreateBeacon(w http.ResponseWriter, r *http.Request) {
 		ScytheHTTPHeaders:       httpOpts.Headers,
 		ScytheHTTPProxy:         httpOpts.Proxy,
 		ScytheHTTPSkipTLSVerify: httpOpts.SkipTLSVerify,
+		ScytheHTTPSocks5Listen:  httpOpts.Socks5Listen,
+		ScytheHTTPSocks5Port:    httpOpts.Socks5Port,
 		ScytheEmbedGOOS:         embedGOOS,
 		ScytheEmbedGOARCH:       embedGOARCH,
 		ScytheExample:           scythe,
@@ -363,6 +374,8 @@ func scytheHTTPOptionsFromInput(in *scytheHTTPInput, prof *dbconnections.BeaconP
 		o.Headers = prof.ScytheHTTPHeaders
 		o.Proxy = prof.ScytheHTTPProxy
 		o.SkipTLSVerify = prof.ScytheHTTPSkipTLSVerify
+		o.Socks5Listen = prof.ScytheHTTPSocks5Listen
+		o.Socks5Port = prof.ScytheHTTPSocks5Port
 	}
 	if in != nil {
 		if in.Method != "" {
@@ -378,6 +391,8 @@ func scytheHTTPOptionsFromInput(in *scytheHTTPInput, prof *dbconnections.BeaconP
 			o.Proxy = in.Proxy
 		}
 		o.SkipTLSVerify = in.SkipTLSVerify
+		o.Socks5Listen = in.Socks5Listen
+		o.Socks5Port = in.Socks5Port
 	}
 	if o.Method == "" {
 		o.Method = "GET"
@@ -450,6 +465,13 @@ func (s *Server) handleAPIScytheEmbedded(w http.ResponseWriter, r *http.Request)
 	if !clientBelongsToEngagement(ctx, req.ClientID, eng.ID.Hex()) {
 		jsonError(w, http.StatusForbidden, "beacon is not in this engagement")
 		return
+	}
+	if req.ScytheHTTP != nil && req.ScytheHTTP.Socks5Listen {
+		p := req.ScytheHTTP.Socks5Port
+		if p < 1 || p > 65535 {
+			jsonError(w, http.StatusBadRequest, "socks5_port must be between 1 and 65535 when socks5_listen is true")
+			return
+		}
 	}
 	var prof *dbconnections.BeaconProfile
 	if p, err := dbconnections.FindBeaconProfileByClientID(ctx, req.ClientID); err == nil {

--- a/pkg/adminpanel/handlers_portal.go
+++ b/pkg/adminpanel/handlers_portal.go
@@ -178,6 +178,10 @@ func (s *Server) handleBeaconsPage(w http.ResponseWriter, r *http.Request) {
   <textarea id="shdrs" rows="2" class="mono" placeholder="e.g. User-Agent:Mozilla/5.0… — do not repeat auth headers"></textarea>
   <label>Proxy (<code>-proxy</code>; optional; pivot proxy is applied when parent is set if this is empty)</label>
   <input id="sproxy" class="mono" placeholder="host:port">
+  <label><input type="checkbox" id="ssocks5"> SOCKS5 listener (<code>-socks5-listen</code> / <code>-socks5-port</code>)</label>
+  <label>SOCKS5 listen port (1–65535; e.g. 9050)</label>
+  <input id="ssocks5port" type="number" min="1" max="65535" value="9050" class="mono" title="Used when SOCKS5 listener is checked">
+  <p class="muted" style="font-size:.82rem;margin:.25rem 0 0">Embeds the same argv Scythe expects (e.g. <code>-socks5-listen</code> <code>-socks5-port</code> <code>9050</code>). Uncheck or leave port invalid to omit.</p>
   <label><input type="checkbox" id="stls"> Skip TLS verify (<code>-skip-tls-verify</code>)</label>
   <label>Embedded binary: target OS (<code>GOOS</code>)</label>
   <select id="sgoos">
@@ -218,6 +222,11 @@ function scytheHttpPayload() {
     headers: document.getElementById('shdrs').value.trim(),
     proxy: document.getElementById('sproxy').value.trim(),
     skip_tls_verify: document.getElementById('stls').checked,
+    socks5_listen: document.getElementById('ssocks5').checked,
+    socks5_port: (function() {
+      var n = parseInt(document.getElementById('ssocks5port').value, 10);
+      return isNaN(n) ? 0 : n;
+    })(),
     goos: document.getElementById('sgoos').value.trim(),
     goarch: document.getElementById('sgoarch').value.trim()
   };

--- a/pkg/dbconnections/portal.go
+++ b/pkg/dbconnections/portal.go
@@ -39,7 +39,9 @@ type BeaconProfile struct {
 	ScytheHTTPDirectories   string    `bson:"scythe_http_directories,omitempty"`
 	ScytheHTTPHeaders       string    `bson:"scythe_http_headers,omitempty"`
 	ScytheHTTPProxy         string    `bson:"scythe_http_proxy,omitempty"`
-	ScytheHTTPSkipTLSVerify bool      `bson:"scythe_http_skip_tls_verify,omitempty"`
+	ScytheHTTPSkipTLSVerify bool `bson:"scythe_http_skip_tls_verify,omitempty"`
+	ScytheHTTPSocks5Listen  bool `bson:"scythe_http_socks5_listen,omitempty"`
+	ScytheHTTPSocks5Port    int  `bson:"scythe_http_socks5_port,omitempty"`
 	ScytheEmbedGOOS         string    `bson:"scythe_embed_goos,omitempty"`
 	ScytheEmbedGOARCH       string    `bson:"scythe_embed_goarch,omitempty"`
 	ScytheExample           string    `bson:"scythe_example"`

--- a/pkg/scythebuild/scythebuild.go
+++ b/pkg/scythebuild/scythebuild.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -26,6 +27,9 @@ type HTTPOptions struct {
 	Headers       string // comma-separated extra key:value pairs; always merged with Content-Type + X-Client-Id + X-API-Secret
 	Proxy         string
 	SkipTLSVerify bool
+	// Socks5Listen enables embedded Scythe SOCKS5 listener (-socks5-listen -socks5-port <port>).
+	Socks5Listen bool
+	Socks5Port   int // 1–65535 when Socks5Listen is true
 }
 
 // DefaultHTTPOptions returns Method GET and Timeout "30s".
@@ -91,6 +95,9 @@ func BuildHTTPEmbedTokens(baseURL, clientID, secret string, o HTTPOptions) []str
 	}
 	if o.SkipTLSVerify {
 		out = append(out, "-skip-tls-verify")
+	}
+	if o.Socks5Listen && o.Socks5Port >= 1 && o.Socks5Port <= 65535 {
+		out = append(out, "-socks5-listen", "-socks5-port", strconv.Itoa(o.Socks5Port))
 	}
 	return out
 }

--- a/pkg/scythebuild/scythebuild_test.go
+++ b/pkg/scythebuild/scythebuild_test.go
@@ -27,6 +27,40 @@ func TestResolveScytheSourceDir_SCYTHE_SRC(t *testing.T) {
 	}
 }
 
+func TestBuildHTTPEmbedTokens_SOCKS5(t *testing.T) {
+	base := "https://c2.example/"
+	cid := "11111111-1111-1111-1111-111111111111"
+	sec := "deadbeef"
+	o := HTTPOptions{Method: "GET", Timeout: "30s", Socks5Listen: true, Socks5Port: 9050}
+	tok := BuildHTTPEmbedTokens(base, cid, sec, o)
+	i := indexOf(tok, "-socks5-listen")
+	if i < 0 || i+2 >= len(tok) {
+		t.Fatalf("missing -socks5-listen / -socks5-port / port: %v", tok)
+	}
+	if tok[i+1] != "-socks5-port" || tok[i+2] != "9050" {
+		t.Fatalf("got %v", tok)
+	}
+}
+
+func indexOf(s []string, want string) int {
+	for i, x := range s {
+		if x == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestBuildHTTPEmbedTokens_NO_SOCKS5WhenInvalid(t *testing.T) {
+	o := HTTPOptions{Socks5Listen: true, Socks5Port: 0}
+	tok := BuildHTTPEmbedTokens("https://x/", "id", "sec", o)
+	for _, x := range tok {
+		if x == "-socks5-listen" {
+			t.Fatalf("should not include socks5: %v", tok)
+		}
+	}
+}
+
 func TestMergeScytheHTTPHeaders(t *testing.T) {
 	const cid = "68902a9a-e40f-4f15-a101-995800fa39b9"
 	const sec = "secrethex"


### PR DESCRIPTION
Persist socks5_listen/socks5_port on beacon profiles; validate port in API. Portal UI checkbox and port field; scythebuild emits -socks5-listen argv. Bump third_party/Scythe so Http accepts those flags and runs local SOCKS5.

Made-with: Cursor