### PR TITLE
Mitre prscan

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+# Focus on first-party code; vendored Scythe is tracked separately via govulncheck/Trivy.
+paths-ignore:
+  - third_party/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+# Static analysis (SAST) for Go. On private repos, uploading to the Security tab
+# usually requires GitHub Advanced Security; the analysis still runs and appears in the workflow log.
+name: CodeQL
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"

--- a/.github/workflows/sast-semgrep-gosec.yml
+++ b/.github/workflows/sast-semgrep-gosec.yml
@@ -1,0 +1,51 @@
+# SAST that works on private repos without GitHub Advanced Security (results in the
+# Actions log; CodeQL SARIF in the Security tab typically needs GHAS on private repos).
+#
+# Other options teams often add: SonarCloud, Snyk Code, Bearer, DeepSource,
+# Trivy filesystem/config scan (`trivy fs .`), or self-hosted Semgrep Team / DefectDojo.
+#
+# Semgrep: not --error by default — this repo uses plain HTTP by design (beacon/admin).
+#   Add --error after triaging, or add per-rule suppressions in code.
+# gosec: only HIGH severity fails the build (tune with -severity).
+name: SAST (Semgrep + gosec)
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Semgrep scan (advisory)
+        run: >
+          semgrep scan
+          --config p/golang
+          --config p/security-audit
+          --exclude-rule go.lang.security.audit.net.use-tls.use-tls
+          --exclude third_party
+
+  gosec:
+    name: gosec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run gosec
+        uses: securego/gosec@v2.22.10
+        with:
+          args: "-exclude-dir=third_party -severity high -fmt text -stdout -verbose=0 ./..."

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,66 @@
+# Supply-chain checks: Go vulncheck (this repo) and npm audit when Node lockfiles exist (HRL-style layout).
+name: Security audit
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  go-vulncheck:
+    runs-on: ubuntu-latest
+    env:
+      # Lets go 1.23 run the latest govulncheck module (requires a newer toolchain).
+      GOTOOLCHAIN: auto
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  npm-audit:
+    # Same convention as harvestrangelabs.com (frontend/backend); extend paths if you add workspaces.
+    # hashFiles() is only valid in step expressions after checkout; detect lockfiles in a step instead.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect npm lockfiles
+        id: locks
+        run: |
+          root=0; [ -f package-lock.json ] && root=1 || true
+          fe=0; [ -f frontend/package-lock.json ] && fe=1 || true
+          be=0; [ -f backend/package-lock.json ] && be=1 || true
+          any=0
+          if [ "$root" = 1 ] || [ "$fe" = 1 ] || [ "$be" = 1 ]; then any=1; fi
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          echo "frontend=$fe" >> "$GITHUB_OUTPUT"
+          echo "backend=$be" >> "$GITHUB_OUTPUT"
+          echo "any=$any" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@v4
+        if: steps.locks.outputs.any == '1'
+        with:
+          node-version: "22"
+
+      - name: npm audit (repository root)
+        if: steps.locks.outputs.root == '1'
+        run: npm ci && npm audit --audit-level=moderate
+
+      - name: npm audit (frontend)
+        if: steps.locks.outputs.frontend == '1'
+        working-directory: frontend
+        run: npm ci && npm audit --audit-level=moderate
+
+      - name: npm audit (backend)
+        if: steps.locks.outputs.backend == '1'
+        working-directory: backend
+        run: npm ci && npm audit --audit-level=moderate

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,39 @@
+# Container image vulnerability scan (matches harvestrangelabs.com severity gate).
+name: Trivy container scan
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image (load into Docker)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: reaperc2:trivy-ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Trivy on image
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: reaperc2:trivy-ci
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          format: table
+          vuln-type: os,library

--- a/pkg/adminpanel/handlers_engagements.go
+++ b/pkg/adminpanel/handlers_engagements.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"ReaperC2/pkg/dbconnections"
+	"ReaperC2/pkg/mitreattack"
 
 	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
@@ -19,6 +20,9 @@ import (
 )
 
 const maxEngagementNotesLen = 50000
+
+// maxEngagementAttackTacticNotesLen caps total characters across all tactic note fields.
+const maxEngagementAttackTacticNotesLen = 50000
 
 func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
 	user, role, ok := s.requireHTMLAuth(w, r)
@@ -112,7 +116,7 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	body := `
 <h1>Engagements</h1>
-<p class="muted">Each engagement scopes <strong>Beacons</strong>, <strong>Commands</strong>, <strong>Reports</strong>, <strong>Topology</strong>, and <strong>Chat</strong>. Use <strong>Workspace</strong> to select it for operator pages. <strong>Manage</strong> sets status, haul type, notes, and (for administrators) <strong>assigned operators</strong>. Closed engagements show a banner pill.</p>
+<p class="muted">Each engagement scopes <strong>Beacons</strong>, <strong>Commands</strong>, <strong>Reports</strong>, <strong>Topology</strong>, and <strong>Chat</strong>. Use <strong>Workspace</strong> to select it for operator pages. <strong>Manage</strong> sets status, haul type, general notes, <strong>MITRE ATT&amp;CK</strong> tactic notes (for Navigator / reports), and (for administrators) <strong>assigned operators</strong>. Closed engagements show a banner pill.</p>
 <div class="card">
   <h2>Your engagements</h2>
   <table><thead><tr><th>Name</th><th>Client</th><th>Start</th><th>End</th><th>Status</th><th>Haul</th><th>Operators</th><th></th></tr></thead><tbody>` + rows.String() + `</tbody></table>
@@ -134,6 +138,7 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
   <label for="engDlgNotes">Notes</label>
   <p class="muted" style="font-size:.82rem;margin:.35rem 0 0">Internal reminders, scope, handoff — not shown to beacons.</p>
   <textarea id="engDlgNotes" placeholder="e.g. pivot rules, reporting window, customer contacts…"></textarea>
+  ` + engagementAttackNotesManageHTML() + `
   <div id="engDlgOpsSection" style="display:none;margin-top:.75rem">
     <label>Assigned operators</label>
     <p class="muted" style="font-size:.82rem;margin:.25rem 0 .35rem">Administrators only: choose which operators can open this workspace. Admins always have access.</p>
@@ -233,6 +238,13 @@ document.querySelectorAll('[data-manage]').forEach(function(btn) {
     if (haul !== 'short_haul' && haul !== 'long_haul') haul = 'interactive';
     document.getElementById('engDlgHaul').value = haul;
     document.getElementById('engDlgNotes').value = j.notes || '';
+    var atkMap = j.attack_tactic_notes || {};
+    document.querySelectorAll('[data-atk-tactic]').forEach(function(el) {
+      var k = el.getAttribute('data-atk-tactic');
+      el.value = (atkMap[k] !== undefined && atkMap[k] !== null) ? atkMap[k] : '';
+    });
+    var navA = document.getElementById('engAtkNavDownload');
+    if (navA) navA.href = '/api/engagements/' + encodeURIComponent(engDlgId) + '/attack-navigator-layer?attack_version=19';
     buildEngDlgOps(j);
     if (dlg.showModal) dlg.showModal(); else dlg.setAttribute('open', '');
   };
@@ -242,10 +254,15 @@ document.getElementById('engDlgSave').onclick = async function() {
   var msg = document.getElementById('engDlgMsg');
   if (!engDlgId) return;
   msg.textContent = 'Saving…';
+  var atk = {};
+  document.querySelectorAll('[data-atk-tactic]').forEach(function(el) {
+    atk[el.getAttribute('data-atk-tactic')] = el.value;
+  });
   var body = {
     status: document.getElementById('engDlgStatus').value,
     haul_type: document.getElementById('engDlgHaul').value,
-    notes: document.getElementById('engDlgNotes').value
+    notes: document.getElementById('engDlgNotes').value,
+    attack_tactic_notes: atk
   };
   if (window.__REAPER_IS_ADMIN__) {
     var aops = [];
@@ -293,14 +310,15 @@ document.getElementById('enCreate').onclick = async function() {
 }
 
 type createEngagementAPI struct {
-	Name              string   `json:"name"`
-	ClientName        string   `json:"client_name"`
-	StartDate         string   `json:"start_date"`
-	EndDate           string   `json:"end_date"`
-	HaulType          string   `json:"haul_type"`
-	SlackDiscordRoom  string   `json:"slack_discord_room"`
-	AssignedOperators []string `json:"assigned_operators"`
-	Notes             string   `json:"notes"`
+	Name              string            `json:"name"`
+	ClientName        string            `json:"client_name"`
+	StartDate         string            `json:"start_date"`
+	EndDate           string            `json:"end_date"`
+	HaulType          string            `json:"haul_type"`
+	SlackDiscordRoom  string            `json:"slack_discord_room"`
+	AssignedOperators []string          `json:"assigned_operators"`
+	Notes             string            `json:"notes"`
+	AttackTacticNotes map[string]string `json:"attack_tactic_notes"`
 }
 
 func parseEngagementDate(s string) (time.Time, error) {
@@ -357,6 +375,10 @@ func (s *Server) handleAPIEngagementsCreate(w http.ResponseWriter, r *http.Reque
 		jsonError(w, http.StatusBadRequest, "notes too long")
 		return
 	}
+	if req.AttackTacticNotes != nil && mitreattack.TacticNotesTotalLen(req.AttackTacticNotes) > maxEngagementAttackTacticNotesLen {
+		jsonError(w, http.StatusBadRequest, "attack tactic notes too long")
+		return
+	}
 	var assign []string
 	for _, u := range req.AssignedOperators {
 		u = strings.TrimSpace(u)
@@ -393,6 +415,7 @@ func (s *Server) handleAPIEngagementsCreate(w http.ResponseWriter, r *http.Reque
 		AssignedOperators: assign,
 		CreatedBy:         user,
 		Notes:             req.Notes,
+		AttackTacticNotes: req.AttackTacticNotes,
 	})
 	if err != nil {
 		log.Printf("admin: insert engagement: %v", err)
@@ -495,19 +518,20 @@ func engagementAPIMap(e *dbconnections.Engagement) map[string]interface{} {
 	}
 	ht := dbconnections.NormalizeEngagementHaulType(e.HaulType)
 	return map[string]interface{}{
-		"id":                 e.ID.Hex(),
-		"name":               e.Name,
-		"client_name":        e.ClientName,
-		"start_date":         e.StartDate.UTC().Format(time.RFC3339),
-		"end_date":           e.EndDate.UTC().Format(time.RFC3339),
-		"slack_discord_room": e.SlackDiscordRoom,
-		"assigned_operators": e.AssignedOperators,
-		"status":             st,
-		"haul_type":          ht,
-		"haul_type_label":    dbconnections.EngagementHaulTypeLabel(ht),
-		"notes":              e.Notes,
-		"created_at":         e.CreatedAt.UTC().Format(time.RFC3339),
-		"created_by":         e.CreatedBy,
+		"id":                  e.ID.Hex(),
+		"name":                e.Name,
+		"client_name":         e.ClientName,
+		"start_date":          e.StartDate.UTC().Format(time.RFC3339),
+		"end_date":            e.EndDate.UTC().Format(time.RFC3339),
+		"slack_discord_room":  e.SlackDiscordRoom,
+		"assigned_operators":  e.AssignedOperators,
+		"status":              st,
+		"haul_type":           ht,
+		"haul_type_label":     dbconnections.EngagementHaulTypeLabel(ht),
+		"notes":               e.Notes,
+		"attack_tactic_notes": mitreattack.FullTacticNoteMap(e.AttackTacticNotes),
+		"created_at":          e.CreatedAt.UTC().Format(time.RFC3339),
+		"created_by":          e.CreatedBy,
 	}
 }
 
@@ -547,10 +571,11 @@ func (s *Server) handleAPIEngagementByID(w http.ResponseWriter, r *http.Request)
 		_ = json.NewEncoder(w).Encode(engagementAPIMap(e))
 	case http.MethodPatch:
 		var req struct {
-			Status              *string   `json:"status"`
-			Notes               *string   `json:"notes"`
-			HaulType            *string   `json:"haul_type"`
-			AssignedOperators   *[]string `json:"assigned_operators"`
+			Status            *string            `json:"status"`
+			Notes             *string            `json:"notes"`
+			AttackTacticNotes *map[string]string `json:"attack_tactic_notes"`
+			HaulType          *string            `json:"haul_type"`
+			AssignedOperators *[]string          `json:"assigned_operators"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			jsonError(w, http.StatusBadRequest, "invalid json")
@@ -568,6 +593,13 @@ func (s *Server) handleAPIEngagementByID(w http.ResponseWriter, r *http.Request)
 			}
 			patch.Notes = req.Notes
 		}
+		if req.AttackTacticNotes != nil {
+			if mitreattack.TacticNotesTotalLen(*req.AttackTacticNotes) > maxEngagementAttackTacticNotesLen {
+				jsonError(w, http.StatusBadRequest, "attack tactic notes too long")
+				return
+			}
+			patch.AttackTacticNotes = req.AttackTacticNotes
+		}
 		if req.HaulType != nil {
 			h := strings.TrimSpace(*req.HaulType)
 			patch.HaulType = &h
@@ -579,7 +611,7 @@ func (s *Server) handleAPIEngagementByID(w http.ResponseWriter, r *http.Request)
 			}
 			patch.AssignedOperators = req.AssignedOperators
 		}
-		if patch.Status == nil && patch.Notes == nil && patch.HaulType == nil && patch.AssignedOperators == nil {
+		if patch.Status == nil && patch.Notes == nil && patch.AttackTacticNotes == nil && patch.HaulType == nil && patch.AssignedOperators == nil {
 			jsonError(w, http.StatusBadRequest, "no changes")
 			return
 		}
@@ -615,4 +647,104 @@ func (s *Server) handleAPIEngagementByID(w http.ResponseWriter, r *http.Request)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+func engagementAttackNotesManageHTML() string {
+	var b strings.Builder
+	b.WriteString(`<details class="atk-notes-manage" open style="margin-top:.75rem;border-top:1px solid var(--border);padding-top:.75rem">`)
+	b.WriteString(`<summary style="cursor:pointer;font-weight:600">MITRE ATT&amp;CK tactic notes</summary>`)
+	b.WriteString(`<p class="muted" style="font-size:.82rem;margin:.5rem 0 .35rem">One field per enterprise tactic (Navigator <code>tactic</code> shortnames). Use for reporting; export loads in <a href="https://mitre-attack.github.io/attack-navigator/" target="_blank" rel="noopener">ATT&amp;CK Navigator</a> with <code>versions.attack</code> 16–19 via <code>?attack_version=</code>.</p>`)
+	for _, t := range mitreattack.EnterpriseTactics() {
+		b.WriteString(`<label for="engAtk_`)
+		b.WriteString(template.HTMLEscapeString(t.Key))
+		b.WriteString(`" style="margin-top:.5rem;display:block">`)
+		b.WriteString(template.HTMLEscapeString(t.Label))
+		b.WriteString(`</label><textarea id="engAtk_`)
+		b.WriteString(template.HTMLEscapeString(t.Key))
+		b.WriteString(`" data-atk-tactic="`)
+		b.WriteString(template.HTMLEscapeString(t.Key))
+		b.WriteString(`" rows="2" class="atk-tactic-note" placeholder="Procedures, techniques, or narrative for this tactic…"></textarea>`)
+	}
+	b.WriteString(`<p style="margin:.6rem 0 0"><a id="engAtkNavDownload" href="#" style="font-size:.85rem">Download Navigator layer JSON (ATT&amp;CK v19)</a></p>`)
+	b.WriteString(`</details>`)
+	return b.String()
+}
+
+func engagementNavigatorDownloadFilename(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		} else if r == ' ' {
+			b.WriteRune('-')
+		}
+	}
+	s := strings.Trim(b.String(), "-")
+	if s == "" {
+		s = "engagement"
+	}
+	return s + "-attack-navigator.json"
+}
+
+func navigatorLayerDescription(e *dbconnections.Engagement) string {
+	var parts []string
+	if strings.TrimSpace(e.Notes) != "" {
+		parts = append(parts, "General notes\n"+strings.TrimSpace(e.Notes))
+	}
+	if d := mitreattack.FormatTacticNotesDescription(e.AttackTacticNotes); d != "" {
+		parts = append(parts, d)
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n\n"))
+}
+
+// handleAPIEngagementAttackNavigatorLayer serves an ATT&CK Navigator layer JSON for one engagement.
+func (s *Server) handleAPIEngagementAttackNavigatorLayer(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user, role, ok := s.sessionUser(r)
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	idHex := strings.TrimSpace(mux.Vars(r)["id"])
+	if idHex == "" {
+		jsonError(w, http.StatusBadRequest, "engagement id required")
+		return
+	}
+	if _, err := primitive.ObjectIDFromHex(idHex); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid engagement id")
+		return
+	}
+	ver, err := mitreattack.ParseAttackVersion(r.URL.Query().Get("attack_version"))
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+	e, err := dbconnections.FindEngagementByID(ctx, idHex)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			jsonError(w, http.StatusNotFound, "engagement not found")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "failed to load engagement")
+		return
+	}
+	if !dbconnections.UserCanAccessEngagement(role, user, e) {
+		jsonError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+	layer := mitreattack.NavigatorLayer(e.Name, navigatorLayerDescription(e), ver)
+	raw, err := mitreattack.MarshalNavigatorLayer(layer)
+	if err != nil {
+		log.Printf("admin: marshal navigator layer: %v", err)
+		jsonError(w, http.StatusInternalServerError, "export failed")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+engagementNavigatorDownloadFilename(e.Name)+`"`)
+	_, _ = w.Write(raw)
 }

--- a/pkg/adminpanel/handlers_portal.go
+++ b/pkg/adminpanel/handlers_portal.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"ReaperC2/pkg/dbconnections"
+	"ReaperC2/pkg/mitreattack"
 
 	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
@@ -401,6 +402,7 @@ func (s *Server) handleReportsPage(w http.ResponseWriter, r *http.Request) {
   <p><a href="/api/reports/export?format=csv&redact=1" download>Download CSV (redacted)</a> — clients table only; use JSON for command history.</p>
   <p><a href="/api/reports/export-ghostwriter?redact=1" download>Ghostwriter CSV (redacted)</a></p>
   <p><a href="/api/reports/export-ghostwriter" download>Ghostwriter CSV (full)</a> — same 13-column Specter Ops schema as Logs: clients, saved profiles, and beacon command output (newest first).</p>
+  <p><a href="/api/reports/attack-navigator-layer?attack_version=19" download>MITRE ATT&amp;CK Navigator layer</a> — from engagement <strong>Manage</strong> notes (general + per-tactic). Default STIX <code>v19</code>; use <code>?attack_version=16</code> through <code>19</code> to match your Navigator bundle.</p>
 </div>`
 	s.writeAppPage(w, user, role, "reports", "Reports", body, eng)
 }
@@ -619,14 +621,16 @@ func (s *Server) handleAPIReportsExport(w http.ResponseWriter, r *http.Request) 
 	}
 
 	type engagementExportSnapshot struct {
-		ID               string `json:"id"`
-		Name             string `json:"name"`
-		ClientName       string `json:"client_name"`
-		StartDate        string `json:"start_date"`
-		EndDate          string `json:"end_date"`
-		HaulType         string `json:"haul_type"`
-		HaulTypeLabel    string `json:"haul_type_label"`
-		SlackDiscordRoom string `json:"slack_discord_room,omitempty"`
+		ID                string            `json:"id"`
+		Name              string            `json:"name"`
+		ClientName        string            `json:"client_name"`
+		StartDate         string            `json:"start_date"`
+		EndDate           string            `json:"end_date"`
+		HaulType          string            `json:"haul_type"`
+		HaulTypeLabel     string            `json:"haul_type_label"`
+		SlackDiscordRoom  string            `json:"slack_discord_room,omitempty"`
+		Notes             string            `json:"notes,omitempty"`
+		AttackTacticNotes map[string]string `json:"attack_tactic_notes,omitempty"`
 	}
 	type exportBundle struct {
 		GeneratedAt   string                               `json:"generated_at"`
@@ -639,14 +643,16 @@ func (s *Server) handleAPIReportsExport(w http.ResponseWriter, r *http.Request) 
 	bundle := exportBundle{
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		Engagement: engagementExportSnapshot{
-			ID:               eng.ID.Hex(),
-			Name:             eng.Name,
-			ClientName:       eng.ClientName,
-			StartDate:        eng.StartDate.UTC().Format(time.RFC3339),
-			EndDate:          eng.EndDate.UTC().Format(time.RFC3339),
-			HaulType:         ht,
-			HaulTypeLabel:    dbconnections.EngagementHaulTypeLabel(ht),
-			SlackDiscordRoom: eng.SlackDiscordRoom,
+			ID:                eng.ID.Hex(),
+			Name:              eng.Name,
+			ClientName:        eng.ClientName,
+			StartDate:         eng.StartDate.UTC().Format(time.RFC3339),
+			EndDate:           eng.EndDate.UTC().Format(time.RFC3339),
+			HaulType:          ht,
+			HaulTypeLabel:     dbconnections.EngagementHaulTypeLabel(ht),
+			SlackDiscordRoom:  eng.SlackDiscordRoom,
+			Notes:             eng.Notes,
+			AttackTacticNotes: mitreattack.CompactTacticNotesForExport(eng.AttackTacticNotes),
 		},
 		Clients:       clients,
 		Profiles:      profiles,
@@ -695,6 +701,37 @@ func (s *Server) handleAPIReportsExport(w http.ResponseWriter, r *http.Request) 
 		}
 		cw.Flush()
 	}
+}
+
+func (s *Server) handleAPIReportsAttackNavigatorLayer(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	user, role, ok := s.sessionUser(r)
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	eng, ok := s.engagementForAPI(w, r, user, role)
+	if !ok {
+		return
+	}
+	ver, err := mitreattack.ParseAttackVersion(r.URL.Query().Get("attack_version"))
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	layer := mitreattack.NavigatorLayer(eng.Name, navigatorLayerDescription(eng), ver)
+	raw, err := mitreattack.MarshalNavigatorLayer(layer)
+	if err != nil {
+		log.Printf("admin: marshal navigator layer (reports): %v", err)
+		jsonError(w, http.StatusInternalServerError, "export failed")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+engagementNavigatorDownloadFilename(eng.Name)+`"`)
+	_, _ = w.Write(raw)
 }
 
 func (s *Server) handleAPIReportsExportGhostwriter(w http.ResponseWriter, r *http.Request) {

--- a/pkg/adminpanel/password.go
+++ b/pkg/adminpanel/password.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -127,7 +128,15 @@ func verifyArgon2idStored(storedHash, plain string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("hash: %w", err)
 	}
-	got := argon2.IDKey([]byte(plain), salt, itime, mem, uint8(threads), uint32(len(want)))
+	if threads > 255 {
+		return false, fmt.Errorf("invalid argon2 parallelism")
+	}
+	lw := len(want)
+	if uint64(lw) > math.MaxUint32 {
+		return false, fmt.Errorf("invalid hash length")
+	}
+	// lw is bounded to fit uint32 (check above); uint8(threads) is bounded to 255.
+	got := argon2.IDKey([]byte(plain), salt, itime, mem, uint8(threads), uint32(lw)) // #nosec G115
 	if len(got) != len(want) {
 		return false, nil
 	}

--- a/pkg/adminpanel/server.go
+++ b/pkg/adminpanel/server.go
@@ -38,11 +38,13 @@ func NewServer() *Server {
 	s.router.HandleFunc("/api/engagements", s.handleAPIEngagements).Methods(http.MethodGet, http.MethodPost)
 	s.router.HandleFunc("/api/engagements/active", s.handleAPIEngagementsActivePOST).Methods(http.MethodPost)
 	s.router.HandleFunc("/api/engagements/{id}", s.handleAPIEngagementByID).Methods(http.MethodGet, http.MethodPatch)
+	s.router.HandleFunc("/api/engagements/{id}/attack-navigator-layer", s.handleAPIEngagementAttackNavigatorLayer).Methods(http.MethodGet)
 
 	s.router.HandleFunc("/api/beacons", s.handleCreateBeacon).Methods(http.MethodPost)
 	s.router.HandleFunc("/api/beacons/scythe-embedded", s.handleAPIScytheEmbedded).Methods(http.MethodPost)
 	s.router.HandleFunc("/api/reports/export", s.handleAPIReportsExport).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/reports/export-ghostwriter", s.handleAPIReportsExportGhostwriter).Methods(http.MethodGet)
+	s.router.HandleFunc("/api/reports/attack-navigator-layer", s.handleAPIReportsAttackNavigatorLayer).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/topology", s.handleAPITopology).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/beacon-presence", s.handleAPIBeaconPresence).Methods(http.MethodGet)
 	s.router.HandleFunc("/api/chat/messages", s.handleAPIChatMessages).Methods(http.MethodGet, http.MethodPost)

--- a/pkg/dbconnections/engagements.go
+++ b/pkg/dbconnections/engagements.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"ReaperC2/pkg/mitreattack"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -67,19 +69,21 @@ func initEngagementsCollection(db *mongo.Database) {
 
 // Engagement is one assessment / operation workspace (scopes beacons, reports, topology, etc.).
 type Engagement struct {
-	ID                 primitive.ObjectID `bson:"_id,omitempty" json:"id"`
-	Name               string             `bson:"name" json:"name"`
-	ClientName         string             `bson:"client_name" json:"client_name"`
-	StartDate          time.Time          `bson:"start_date" json:"start_date"`
-	EndDate            time.Time          `bson:"end_date" json:"end_date"`
-	SlackDiscordRoom   string             `bson:"slack_discord_room,omitempty" json:"slack_discord_room,omitempty"`
-	AssignedOperators  []string           `bson:"assigned_operators" json:"assigned_operators"`
-	CreatedAt          time.Time          `bson:"created_at" json:"created_at"`
-	CreatedBy          string             `bson:"created_by,omitempty" json:"created_by,omitempty"`
+	ID                primitive.ObjectID `bson:"_id,omitempty" json:"id"`
+	Name              string             `bson:"name" json:"name"`
+	ClientName        string             `bson:"client_name" json:"client_name"`
+	StartDate         time.Time          `bson:"start_date" json:"start_date"`
+	EndDate           time.Time          `bson:"end_date" json:"end_date"`
+	SlackDiscordRoom  string             `bson:"slack_discord_room,omitempty" json:"slack_discord_room,omitempty"`
+	AssignedOperators []string           `bson:"assigned_operators" json:"assigned_operators"`
+	CreatedAt         time.Time          `bson:"created_at" json:"created_at"`
+	CreatedBy         string             `bson:"created_by,omitempty" json:"created_by,omitempty"`
 	// Status is open or closed (legacy documents with no field are treated as open).
 	Status string `bson:"status,omitempty" json:"status,omitempty"`
 	// Notes is free-form operator text (scope, reminders, handoff).
 	Notes string `bson:"notes,omitempty" json:"notes,omitempty"`
+	// AttackTacticNotes maps enterprise ATT&CK tactic keys (Navigator shortnames) to operator notes.
+	AttackTacticNotes map[string]string `bson:"attack_tactic_notes,omitempty" json:"attack_tactic_notes,omitempty"`
 	// HaulType is interactive | short_haul | long_haul (planning / reporting category).
 	HaulType string `bson:"haul_type,omitempty" json:"haul_type,omitempty"`
 }
@@ -106,6 +110,7 @@ func InsertEngagement(ctx context.Context, e Engagement) (primitive.ObjectID, er
 		e.Status = EngagementStatusOpen
 	}
 	e.HaulType = NormalizeEngagementHaulType(e.HaulType)
+	e.AttackTacticNotes = mitreattack.NormalizeTacticNotes(e.AttackTacticNotes)
 	res, err := EngagementsCollection.InsertOne(ctx, e)
 	if err != nil {
 		return primitive.NilObjectID, err
@@ -210,10 +215,11 @@ func EngagementIsOpen(e *Engagement) bool {
 
 // EngagementPatch is a partial update for engagements.
 type EngagementPatch struct {
-	Status             *string   // "open" | "closed", or nil to skip
-	Notes              *string   // nil = skip; empty string clears notes
-	HaulType           *string   // nil = skip; validated when set
-	AssignedOperators  *[]string // nil = skip; replaces list; each user must exist and not be disabled
+	Status            *string            // "open" | "closed", or nil to skip
+	Notes             *string            // nil = skip; empty string clears notes
+	AttackTacticNotes *map[string]string // nil = skip; empty map clears tactic notes
+	HaulType          *string            // nil = skip; validated when set
+	AssignedOperators *[]string          // nil = skip; replaces list; each user must exist and not be disabled
 }
 
 // UpdateEngagement applies non-nil patch fields. Validates status when set.
@@ -236,6 +242,14 @@ func UpdateEngagement(ctx context.Context, idHex string, patch EngagementPatch) 
 	}
 	if patch.Notes != nil {
 		set["notes"] = *patch.Notes
+	}
+	if patch.AttackTacticNotes != nil {
+		norm := mitreattack.NormalizeTacticNotes(*patch.AttackTacticNotes)
+		if norm == nil {
+			set["attack_tactic_notes"] = bson.M{}
+		} else {
+			set["attack_tactic_notes"] = norm
+		}
 	}
 	if patch.HaulType != nil {
 		h := strings.ToLower(strings.TrimSpace(*patch.HaulType))

--- a/pkg/mitreattack/tactics.go
+++ b/pkg/mitreattack/tactics.go
@@ -1,0 +1,211 @@
+// Package mitreattack holds MITRE ATT&CK enterprise matrix metadata used for engagement notes
+// and ATT&CK Navigator layer exports. Tactic keys match Navigator's tactic shortnames
+// (enterprise-attack) and are stable across ATT&CK releases v16–v19.
+package mitreattack
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// MinAttackVersion and MaxAttackVersion bound supported ATT&CK STIX bundle versions for Navigator exports.
+const MinAttackVersion = 16
+const MaxAttackVersion = 19
+
+// Tactic is one enterprise ATT&CK tactic row (Navigator / layer JSON "tactic" field uses Key).
+type Tactic struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+}
+
+// enterpriseTacticsOrdered is the full enterprise matrix tactic list in standard left-to-right order.
+var enterpriseTacticsOrdered = []Tactic{
+	{Key: "reconnaissance", Label: "Reconnaissance"},
+	{Key: "resource-development", Label: "Resource Development"},
+	{Key: "initial-access", Label: "Initial Access"},
+	{Key: "execution", Label: "Execution"},
+	{Key: "persistence", Label: "Persistence"},
+	{Key: "privilege-escalation", Label: "Privilege Escalation"},
+	{Key: "defense-evasion", Label: "Defense Evasion"},
+	{Key: "credential-access", Label: "Credential Access"},
+	{Key: "discovery", Label: "Discovery"},
+	{Key: "lateral-movement", Label: "Lateral Movement"},
+	{Key: "collection", Label: "Collection"},
+	{Key: "command-and-control", Label: "Command and Control"},
+	{Key: "exfiltration", Label: "Exfiltration"},
+	{Key: "impact", Label: "Impact"},
+}
+
+// EnterpriseTactics returns a defensive copy of the ordered enterprise tactic list.
+func EnterpriseTactics() []Tactic {
+	out := make([]Tactic, len(enterpriseTacticsOrdered))
+	copy(out, enterpriseTacticsOrdered)
+	return out
+}
+
+var validTacticKey = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(enterpriseTacticsOrdered))
+	for _, t := range enterpriseTacticsOrdered {
+		m[t.Key] = struct{}{}
+	}
+	return m
+}()
+
+// IsValidTacticKey reports whether key is a known enterprise tactic shortname.
+func IsValidTacticKey(key string) bool {
+	_, ok := validTacticKey[strings.TrimSpace(key)]
+	return ok
+}
+
+// NormalizeTacticNotes keeps only known tactic keys and trims whitespace; omits empty values.
+func NormalizeTacticNotes(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	for k, v := range in {
+		k = strings.TrimSpace(k)
+		if !IsValidTacticKey(k) {
+			continue
+		}
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// TacticNotesTotalLen returns the combined rune length of all note values (for size limits).
+func TacticNotesTotalLen(m map[string]string) int {
+	n := 0
+	for _, v := range m {
+		n += len([]rune(v))
+	}
+	return n
+}
+
+// FormatTacticNotesDescription builds plain text for Navigator layer description and reports.
+func FormatTacticNotesDescription(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		label := k
+		for _, t := range enterpriseTacticsOrdered {
+			if t.Key == k {
+				label = t.Label
+				break
+			}
+		}
+		b.WriteString(label)
+		b.WriteString("\n")
+		b.WriteString(m[k])
+		b.WriteString("\n\n")
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// ParseAttackVersion normalizes ?attack_version= for Navigator exports (16–19 inclusive).
+func ParseAttackVersion(s string) (int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return MaxAttackVersion, nil
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("attack_version must be an integer")
+	}
+	if v < MinAttackVersion || v > MaxAttackVersion {
+		return 0, fmt.Errorf("attack_version must be between %d and %d", MinAttackVersion, MaxAttackVersion)
+	}
+	return v, nil
+}
+
+// NavigatorLayer returns a layer object compatible with ATT&CK Navigator when serialized as JSON.
+// techniques may be empty; description carries tactic-aligned engagement notes for reporting.
+func NavigatorLayer(name, description string, attackVersion int) map[string]interface{} {
+	av := strconv.Itoa(attackVersion)
+	return map[string]interface{}{
+		"name":        name,
+		"domain":      "enterprise-attack",
+		"description": description,
+		"versions": map[string]interface{}{
+			"attack":    av,
+			"navigator": "4.10.0",
+			"layer":     "4.4",
+		},
+		"filters": map[string]interface{}{},
+		"sorting": 0,
+		"layout": map[string]interface{}{
+			"layout":              "side",
+			"aggregateFunction":   "average",
+			"showID":              false,
+			"showName":            true,
+			"showAggregateScores": false,
+			"countUnscored":       false,
+		},
+		"hideDisabled":                  false,
+		"techniques":                    []interface{}{},
+		"gradient":                      defaultGradient(),
+		"legendItems":                   []interface{}{},
+		"metadata":                      []interface{}{},
+		"links":                         []interface{}{},
+		"showTacticRowBackground":       false,
+		"selectTechniquesAcrossTactics": true,
+		"selectSubtechniquesWithParent": true,
+	}
+}
+
+func defaultGradient() map[string]interface{} {
+	return map[string]interface{}{
+		"colors": []string{
+			"#ff6666ff",
+			"#ffe766ff",
+			"#8ec843ff",
+		},
+		"minValue": 0,
+		"maxValue": 100,
+	}
+}
+
+// MarshalNavigatorLayer JSON-encodes a Navigator layer with stable key ordering where possible.
+func MarshalNavigatorLayer(layer map[string]interface{}) ([]byte, error) {
+	return json.MarshalIndent(layer, "", "  ")
+}
+
+// FullTacticNoteMap returns every enterprise tactic key with stored text or empty string (API / forms).
+func FullTacticNoteMap(stored map[string]string) map[string]string {
+	out := make(map[string]string, len(enterpriseTacticsOrdered))
+	for _, t := range enterpriseTacticsOrdered {
+		out[t.Key] = ""
+	}
+	if stored == nil {
+		return out
+	}
+	for k, v := range stored {
+		if !IsValidTacticKey(k) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// CompactTacticNotesForExport returns only non-empty tactic notes, or nil if none (JSON report / brevity).
+func CompactTacticNotesForExport(stored map[string]string) map[string]string {
+	return NormalizeTacticNotes(stored)
+}

--- a/pkg/mitreattack/tactics_test.go
+++ b/pkg/mitreattack/tactics_test.go
@@ -1,0 +1,46 @@
+package mitreattack
+
+import "testing"
+
+func TestParseAttackVersion(t *testing.T) {
+	v, err := ParseAttackVersion("")
+	if err != nil || v != MaxAttackVersion {
+		t.Fatalf("empty: got %d %v", v, err)
+	}
+	for _, s := range []string{"16", "17", "18", "19"} {
+		got, err := ParseAttackVersion(s)
+		want := int(s[0]-'0')*10 + int(s[1]-'0')
+		if err != nil || got != want {
+			t.Fatalf("version %s: got %d %v", s, got, err)
+		}
+	}
+	_, err = ParseAttackVersion("15")
+	if err == nil {
+		t.Fatal("expected error for 15")
+	}
+	_, err = ParseAttackVersion("20")
+	if err == nil {
+		t.Fatal("expected error for 20")
+	}
+}
+
+func TestNormalizeTacticNotes(t *testing.T) {
+	m := NormalizeTacticNotes(map[string]string{
+		"execution":      "  ran x  ",
+		"bogus":          "drop",
+		"initial-access": "",
+	})
+	if len(m) != 1 || m["execution"] != "ran x" {
+		t.Fatalf("got %#v", m)
+	}
+}
+
+func TestFullTacticNoteMap(t *testing.T) {
+	full := FullTacticNoteMap(map[string]string{"impact": "test"})
+	if full["impact"] != "test" || full["execution"] != "" {
+		t.Fatalf("got %#v", full)
+	}
+	if len(full) != len(EnterpriseTactics()) {
+		t.Fatalf("len %d", len(full))
+	}
+}


### PR DESCRIPTION
feat(engagements): MITRE ATT&CK tactic notes and Navigator layer export
    
    Store per-tactic notes on engagements, validate total size, and expose
    Attack Navigator JSON from reports and engagement manage UI. Add mitreattack
    package for tactic metadata and layer building; extend JSON report export.
    
    Co-authored-by: Cursor <cursoragent@cursor.com>

ci(security): add CodeQL, Trivy, govulncheck, Semgrep/gosec; fix npm-audit job if
    
    - Workflows for supply chain (govulncheck), optional npm audit after checkout,
      image Trivy scan, CodeQL Go, and Semgrep+gosec for private repos without GHAS.
    - Replace job-level hashFiles (invalid) with lockfile detection step.
    - Harden Argon2 verify parameters for gosec (bounds + documented nosec).
    
    Co-authored-by: Cursor <cursoragent@cursor.com>

