### PR TITLE
Admin UI polish, engagement operators, and K8s admin access docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,14 +168,52 @@ docker build -t reaperc2:latest .
 
 Or rely on the Dockerfile clone: `docker build -t reaperc2:latest .` (uses `SCYTHE_GIT_REF`, default `main`). Push to your registry, then point **`deployments/k8s/**`** manifests at that tag. CI should either run **`git submodule update --init --recursive`** before **`docker build`**, or set **`--build-arg SCYTHE_GIT_REF=…`** to match the Scythe revision you intend to ship.
 
+### Kubernetes: public beacon, admin on localhost (tunnel)
+
+ReaperC2 listens on **two ports** in one process by default: the **beacon API** on **8080** and the **operator admin UI** on **8443** (see `BEACON_ADDR` / `ADMIN_ADDR` in the table below). For cluster deployments you should treat them differently:
+
+- **Beacons / Scythe:** expose **8080** to the Internet via your Ingress or load balancer (TLS termination in front of the Service is fine). The sample manifests under [`deployments/k8s/`](deployments/k8s/) wire **only** port **8080** on `reaperc2-service` to the public host.
+- **Admin panel:** do **not** put **8443** on a public Ingress or load balancer. Instead, from a trusted workstation, open a **tunnel** to **8443** on the ReaperC2 Pod or Deployment and use the UI at **`http://127.0.0.1:8443`** on that machine.
+
+**Typical: `kubectl port-forward`**
+
+```bash
+kubectl port-forward -n reaperc2-ns deployment/reaperc2-deployment 8443:8443
+```
+
+Leave that process running, then in a browser on the same machine open **`http://127.0.0.1:8443/login`**. The admin server uses plain HTTP on that port unless you change the binary or put TLS in front of it yourself.
+
+To forward to a specific Pod (useful if the Deployment name differs):
+
+```bash
+kubectl port-forward -n reaperc2-ns pod/$(kubectl get pod -n reaperc2-ns -l app=reaperc2-deployment -o jsonpath='{.items[0].metadata.name}') 8443:8443
+```
+
+Adjust **`-n`**, **labels**, and **Deployment/Pod** names to match your YAML.
+
+**Jump host: SSH local forward after `port-forward` on the bastion**
+
+If your laptop cannot reach the Kubernetes API directly but you can SSH to a bastion that has `kubectl` and kubeconfig:
+
+1. On the bastion, run **`kubectl port-forward … 8443:8443`** as above (it listens on the bastion’s loopback).
+2. From your laptop: **`ssh -N -L 8443:127.0.0.1:8443 user@bastion.example.com`**
+3. Open **`http://127.0.0.1:8443/login`** on the laptop.
+
+**Beacon base URL for implants**
+
+Configure **`BEACON_PUBLIC_BASE_URL`** (and/or each beacon’s **Beacon C2 base URL** in the UI) to the **public** origin that beacons should call—e.g. `https://c2.example.com` where your Ingress terminates and forwards to **8080**. That must **not** be `http://127.0.0.1:8443`; localhost is only for operators via the tunnel.
+
+**Optional:** set **`ADMIN_DISABLE=1`** on the workload if you want **no** admin listener at all (beacon-only); you lose the web UI unless you run a separate pattern.
+
 ### Requirements
 
 * Kubernetes Cluster
 * Traefik routing - Update routing from deployments/k8s/full-deployment.yaml if you are using something else
-* A domain for your http(s) requests
+* A domain for your http(s) requests (for **beacon** traffic to **8080**; admin **8443** should stay off public routes—use the tunnel pattern above)
 
 ### Yaml Updates
 
+* Keep **Ingress / IngressRoute** pointed only at the **beacon** Service port **8080**. Do not add a public path or listener for **8443** unless you intentionally expose the admin panel (not recommended).
 * Add your subdomain to the full-deployment.yaml
 * Add your docker registry secret to full-deployment.yaml
 * Add your secrets that match your golang binary to allow the connections to mongodb to work

--- a/pkg/adminpanel/handlers_engagements.go
+++ b/pkg/adminpanel/handlers_engagements.go
@@ -104,16 +104,16 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
 		if o.Username == "" || dbconnections.OperatorIsDisabled(&o) {
 			continue
 		}
-		opChecks.WriteString(`<label style="display:block;margin:.35rem 0"><input type="checkbox" name="op" value="`)
+		opChecks.WriteString(`<label class="eng-op-check"><input type="checkbox" name="op" value="`)
 		opChecks.WriteString(template.HTMLEscapeString(o.Username))
-		opChecks.WriteString(`"> `)
+		opChecks.WriteString(`"><span class="eng-op-check-box" aria-hidden="true"></span><span class="eng-op-check-text">`)
 		opChecks.WriteString(template.HTMLEscapeString(o.Username))
 		if o.Role != "" {
 			opChecks.WriteString(` <span class="muted">(`)
 			opChecks.WriteString(template.HTMLEscapeString(o.Role))
 			opChecks.WriteString(`)</span>`)
 		}
-		opChecks.WriteString(`</label>`)
+		opChecks.WriteString(`</span></label>`)
 	}
 	body := `
 <h1>Engagements</h1>
@@ -140,7 +140,7 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
   <div id="engDlgOpsSection" style="display:none;margin-top:.75rem">
     <label>Assigned operators</label>
     <p class="muted" style="font-size:.82rem;margin:.25rem 0 .35rem">Administrators only: choose which operators can open this workspace. Admins always have access.</p>
-    <div id="engDlgOpChecks" style="margin-top:.35rem"></div>
+    <div id="engDlgOpChecks" class="eng-op-checks"></div>
   </div>
   <p id="engDlgMsg" class="cmd-inline-msg muted"></p>
   <div class="dlg-actions">
@@ -164,13 +164,12 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
     <option value="short_haul">Short Haul</option>
     <option value="long_haul">Long Haul</option>
   </select>
-  <p class="muted" style="font-size:.82rem;margin:.25rem 0 0">Used for engagement planning and included in report exports.</p>
   <label>Slack / Discord room name</label>
   <input id="enRoom" placeholder="e.g. #acme-2026-ops — used as chat room key">
   <label>Notes (optional)</label>
   <textarea id="enNotes" rows="3" placeholder="Initial scope or reminders"></textarea>
   <label>Assigned operators</label>
-  <div id="opChecks" style="margin-top:.35rem">` + opChecks.String() + `</div>
+  <div id="opChecks" class="eng-op-checks">` + opChecks.String() + `</div>
   <p class="muted" style="font-size:.85rem">Operators listed here can open this engagement. Admins can access every engagement.</p>
   <button type="button" class="btn" id="enCreate">Create</button>
   <p id="enMsg" class="cmd-inline-msg muted"></p>
@@ -178,6 +177,68 @@ func (s *Server) handleEngagementsPage(w http.ResponseWriter, r *http.Request) {
 <style>
 .eng-st-open { color: var(--ok-bright); font-weight: 600; font-size: .85rem; }
 .eng-st-closed { color: var(--muted); font-weight: 600; font-size: .85rem; }
+.eng-op-checks { margin-top: .35rem; max-width: 100%; }
+label.eng-op-check {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0.12rem 0;
+  padding: 0.15rem 0;
+  cursor: pointer;
+  max-width: 32rem;
+  position: relative;
+}
+label.eng-op-check input[type="checkbox"] {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 2;
+}
+label.eng-op-check .eng-op-check-box {
+  flex: 0 0 auto;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--input-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+}
+label.eng-op-check:hover .eng-op-check-box {
+  border-color: var(--accent);
+  background: var(--nav-hover);
+}
+label.eng-op-check input:focus-visible + .eng-op-check-box {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+label.eng-op-check input:checked + .eng-op-check-box {
+  background: var(--accent);
+  border-color: var(--accent-dim);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+}
+label.eng-op-check input:checked + .eng-op-check-box::after {
+  content: "";
+  width: 0.28rem;
+  height: 0.45rem;
+  border: solid var(--bg);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+  margin-bottom: 2px;
+  border-radius: 0 1px 0 0;
+}
+label.eng-op-check .eng-op-check-text {
+  font-size: 0.9rem;
+  line-height: 1.25;
+}
 </style>
 <script>
 window.__REAPER_IS_ADMIN__ = ` + map[bool]string{true: "true", false: "false"}[isAdminUser] + `;
@@ -198,20 +259,26 @@ function buildEngDlgOps(j) {
   (window.ENG_OPS_META || []).forEach(function(op) {
     if (op.disabled) return;
     var lab = document.createElement('label');
-    lab.style.display = 'block';
-    lab.style.margin = '.35rem 0';
+    lab.className = 'eng-op-check';
     var inp = document.createElement('input');
     inp.type = 'checkbox';
     inp.value = op.username;
     if (assigned[op.username]) inp.checked = true;
-    lab.appendChild(inp);
-    lab.appendChild(document.createTextNode(' ' + op.username));
+    var chkBox = document.createElement('span');
+    chkBox.className = 'eng-op-check-box';
+    chkBox.setAttribute('aria-hidden', 'true');
+    var txt = document.createElement('span');
+    txt.className = 'eng-op-check-text';
+    txt.appendChild(document.createTextNode(op.username));
     if (op.role) {
       var sp = document.createElement('span');
       sp.className = 'muted';
       sp.textContent = ' (' + op.role + ')';
-      lab.appendChild(sp);
+      txt.appendChild(sp);
     }
+    lab.appendChild(inp);
+    lab.appendChild(chkBox);
+    lab.appendChild(txt);
     box.appendChild(lab);
   });
 }

--- a/pkg/adminpanel/handlers_logs.go
+++ b/pkg/adminpanel/handlers_logs.go
@@ -41,7 +41,7 @@ func (s *Server) handleLogsPage(w http.ResponseWriter, r *http.Request) {
 <h1>All audit logs</h1>
 <p class="muted">Every engagement and global events (e.g. user creation, full exports). Beacon rows include <strong>Engagement</strong> when known. For one engagement only, use <a href="/engagement/logs">Engagement logs</a>. Details may truncate; JSON export has full text (includes <code>operator_chat</code>).</p>
 <style>
-.logs-export-grid { display: grid; gap: 1rem; grid-template-columns: 1fr; max-width: 48rem; }
+.logs-export-grid { display: grid; gap: 1rem; grid-template-columns: 1fr; width: 100%; max-width: 100%; }
 @media (min-width: 640px) { .logs-export-grid { grid-template-columns: 1fr 1fr; } }
 .log-card-head { display: flex; gap: .85rem; align-items: flex-start; margin: 0 0 .65rem; }
 .log-card-head h2 { margin: 0; font-size: 1.05rem; }
@@ -78,7 +78,7 @@ func (s *Server) handleLogsPage(w http.ResponseWriter, r *http.Request) {
 </div>
 <div class="card">
   <h2>Recent (500)</h2>
-  <table><thead><tr><th>Time</th><th>Actor</th><th>Action</th><th>Engagement</th><th>Details</th></tr></thead><tbody>` + tbl + `</tbody></table>
+  <table class="audit-log-table audit-log-table--all"><thead><tr><th>Time</th><th>Actor</th><th>Action</th><th>Engagement</th><th>Details</th></tr></thead><tbody>` + tbl + `</tbody></table>
 </div>`
 	s.writeAppPage(w, u, role, "logs", "All logs", body, nil)
 }
@@ -118,7 +118,7 @@ func buildAuditLogTableHTML(entries []dbconnections.AuditLogEntry, showEngagemen
 			tbl.WriteString(template.HTMLEscapeString(engCell))
 			tbl.WriteString("</td>")
 		}
-		tbl.WriteString(`<td class="mono">`)
+		tbl.WriteString(`<td class="mono audit-log-details">`)
 		tbl.WriteString(template.HTMLEscapeString(detail))
 		tbl.WriteString("</td></tr>")
 	}
@@ -176,7 +176,7 @@ func (s *Server) handleEngagementLogsPage(w http.ResponseWriter, r *http.Request
 </div>
 <div class="card">
   <h2>Recent (500)</h2>
-  <table><thead><tr><th>Time</th><th>Actor</th><th>Action</th><th>Details</th></tr></thead><tbody>` + tbl + `</tbody></table>
+  <table class="audit-log-table audit-log-table--eng"><thead><tr><th>Time</th><th>Actor</th><th>Action</th><th>Details</th></tr></thead><tbody>` + tbl + `</tbody></table>
 </div>`
 	s.writeAppPage(w, u, role, "englogs", "Engagement logs", body, eng)
 }

--- a/pkg/adminpanel/handlers_portal.go
+++ b/pkg/adminpanel/handlers_portal.go
@@ -21,6 +21,18 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+// beaconEmbeddedHostRunHTML documents the TERM_HARVEST gate for compiled Scythe.embedded binaries
+// (see Scythe pkg/userinput/embedded.go). Shown on the Beacons page and under each saved profile.
+const beaconEmbeddedHostRunHTML = `<details class="beacon-run-host"><summary><strong>Run embedded binary on the host</strong> (<code>TERM_HARVEST=9</code>)</summary>
+<p class="muted" style="font-size:.85rem;margin:.5rem 0">The binary expects this environment variable before it starts the embedded beacon. Examples use <code>Scythe</code> as the program name; use your path if the file is named differently (e.g. <code>Scythe.embedded</code> right after download).</p>
+<ul class="muted" style="font-size:.85rem;margin:0;padding-left:1.25rem;line-height:1.55">
+<li><strong>Linux</strong> — <code>export TERM_HARVEST=9 &amp;&amp; ./Scythe</code></li>
+<li><strong>macOS (Darwin)</strong> — <code>export TERM_HARVEST=9 &amp;&amp; ./Scythe</code></li>
+<li><strong>Windows CMD</strong> — <code>set TERM_HARVEST=9 &amp;&amp; .\Scythe.exe</code></li>
+<li><strong>Windows PowerShell</strong> — <code>$env:TERM_HARVEST='9'; .\Scythe.exe</code></li>
+</ul>
+</details>`
+
 func (s *Server) writeAppPage(w http.ResponseWriter, user, role, active, title, bodyHTML string, eng *dbconnections.Engagement) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
@@ -137,6 +149,7 @@ func (s *Server) handleBeaconsPage(w http.ResponseWriter, r *http.Request) {
 		rows.WriteString(`</pre><button type="button" class="btn-tiny" onclick="copyBeaconField('`)
 		rows.WriteString(idScythe)
 		rows.WriteString(`')">Copy</button></div>`)
+		rows.WriteString(beaconEmbeddedHostRunHTML)
 		rows.WriteString(`</div></details><button type="button" class="btn btn-secondary" data-embed="`)
 		rows.WriteString(template.HTMLEscapeString(p.ClientID))
 		rows.WriteString(`" title="Rebuild and download Scythe with this profile's saved Http options">Scythe.embedded</button><button type="button" class="btn btn-kill" data-kill="`)
@@ -204,7 +217,7 @@ func (s *Server) handleBeaconsPage(w http.ResponseWriter, r *http.Request) {
   <div id="embedDlWrap" style="display:none;margin-top:.75rem;max-width:520px">
     <p id="embedProgLbl" class="muted" style="margin:0 0 .35rem;font-size:.9rem"></p>
     <progress id="embedProg" max="100" style="width:100%;height:1.25rem;vertical-align:middle"></progress>
-  </div>
+  </div>` + beaconEmbeddedHostRunHTML + `
   <pre id="out" style="margin-top:1rem;display:none;"></pre>
   <p class="muted" style="margin-top:.75rem;font-size:.85rem">The JSON response also appears here until you leave the page. Saved profiles keep <strong>Client ID</strong>, <strong>secret</strong>, and URLs under <strong>View credentials</strong> after refresh.</p>
   <button type="button" class="btn btn-secondary" id="reflist" style="margin-top:.35rem">Refresh profile list</button>

--- a/pkg/adminpanel/ui.go
+++ b/pkg/adminpanel/ui.go
@@ -6,6 +6,7 @@ import (
 )
 
 const adminThemeStorageKey = "reaperc2-admin-theme"
+const adminNavSidebarKey = "reaperc2-nav-collapsed"
 
 func themeFontLinks() string {
 	return `<link rel="preconnect" href="https://fonts.googleapis.com">
@@ -15,6 +16,10 @@ func themeFontLinks() string {
 
 func themeBootScript() string {
 	return `<script>(function(){var k='` + adminThemeStorageKey + `';var t=localStorage.getItem(k);if(t!=='light'&&t!=='dark'){t=window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}document.documentElement.setAttribute('data-theme',t);})();</script>`
+}
+
+func navSidebarBootScript() string {
+	return `<script>(function(){var k='` + adminNavSidebarKey + `';document.documentElement.setAttribute('data-sidebar',localStorage.getItem(k)==='1'?'collapsed':'expanded');})();</script>`
 }
 
 func navItem(href, label, active, slug string) string {
@@ -50,6 +55,7 @@ func layoutHTML(username, role, active, title, bodyHTML, engagementBannerHTML, e
 <meta name="viewport" content="width=device-width, initial-scale=1">
 ` + themeFontLinks() + `
 ` + themeBootScript() + `
+` + navSidebarBootScript() + `
 <title>` + template.HTMLEscapeString(title+" — ReaperC2") + `</title>
 <style>
 /* Harvest Range Labs palette — harvestrangelabs.com (dark default + html[data-theme="light"]) */
@@ -115,10 +121,35 @@ body::before {
 }
 body > aside, body > main { position: relative; z-index: 1; }
 aside {
-  width: 220px; flex-shrink: 0; background: var(--panel); border-right: 1px solid var(--border);
+  width: 220px; min-width: 220px; max-width: 220px; flex-shrink: 0; background: var(--panel); border-right: 1px solid var(--border);
   padding: 1rem 0; display: flex; flex-direction: column;
+  transition: min-width 0.22s ease, max-width 0.22s ease, width 0.22s ease, opacity 0.18s ease, padding 0.22s ease, border-color 0.22s ease;
+  overflow: hidden;
 }
-aside .brand { font-weight: 700; padding: 0 1rem 1rem; border-bottom: 1px solid var(--border); margin-bottom: .5rem; }
+html[data-sidebar="collapsed"] aside {
+  min-width: 0; max-width: 0; width: 0; opacity: 0; padding-left: 0; padding-right: 0; border-right-color: transparent;
+  pointer-events: none;
+}
+aside .brand-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;
+  padding: 0 1rem 1rem; border-bottom: 1px solid var(--border); margin-bottom: 0.5rem;
+}
+aside .brand-title { font-weight: 700; }
+.nav-sidebar-collapse {
+  flex: 0 0 auto; margin: 0; padding: 0.25rem 0.45rem; font-size: 1rem; line-height: 1;
+  font-family: var(--font-mono); cursor: pointer; border-radius: 2px;
+  border: 1px solid var(--border); background: var(--input-bg); color: var(--muted);
+}
+.nav-sidebar-collapse:hover { color: var(--accent); border-color: var(--accent); }
+.nav-sidebar-reveal {
+  display: none; position: fixed; left: 0; top: 50%; transform: translateY(-50%); z-index: 50;
+  width: 2rem; min-height: 3.25rem; margin: 0; padding: 0; align-items: center; justify-content: center;
+  border: 1px solid var(--border); border-left: none; border-radius: 0 6px 6px 0;
+  background: var(--panel); color: var(--accent); cursor: pointer; font-size: 1.15rem; line-height: 1;
+  font-family: var(--font-mono); box-shadow: 2px 0 8px rgba(0,0,0,0.2);
+}
+html[data-sidebar="collapsed"] .nav-sidebar-reveal { display: flex; }
+.nav-sidebar-reveal:hover { filter: brightness(1.08); }
 .engagement-bar {
   font-size: .82rem; padding: .5rem 1rem; border-bottom: 1px solid var(--border); background: var(--input-bg);
   line-height: 1.35;
@@ -159,20 +190,41 @@ aside .foot button[type="submit"] { background: none; border: none; color: var(-
   cursor: pointer;
 }
 .theme-toggle:hover { color: var(--accent); border-color: var(--accent); }
-main { flex: 1; padding: 1.5rem 2rem; overflow: auto; max-width: 56rem; position: relative; }
+main {
+  flex: 1;
+  min-width: 0;
+  width: 100%;
+  max-width: none;
+  padding: 1.5rem clamp(1rem, 2.5vw, 2rem);
+  overflow: auto;
+  position: relative;
+  box-sizing: border-box;
+}
 main h1 { font-size: 1.35rem; margin: 0 0 1rem; }
 .toast-host {
   position: fixed; top: 0; left: 220px; right: 0; z-index: 1000; pointer-events: none;
   display: flex; flex-direction: column; align-items: center; padding: .75rem 1rem; gap: .35rem;
+  transition: left 0.22s ease;
 }
+html[data-sidebar="collapsed"] .toast-host { left: 0; }
 .toast-host .toast {
   pointer-events: auto; background: var(--ok); color: #fff; padding: .65rem 1.25rem; border-radius: 8px;
   font-size: .9rem; box-shadow: 0 4px 14px rgba(0,0,0,.45); max-width: min(42rem, calc(100vw - 240px));
-  transition: opacity .45s ease, transform .45s ease;
+  transition: opacity .45s ease, transform .45s ease, max-width 0.22s ease;
 }
+html[data-sidebar="collapsed"] .toast-host .toast { max-width: min(42rem, calc(100vw - 1.5rem)); }
 .toast-host .toast.toast-out { opacity: 0; transform: translateY(-6px); }
 main h2 { font-size: 1.05rem; margin: 1.5rem 0 .75rem; color: var(--muted); font-weight: 600; }
-.card { background: var(--panel); border: 1px solid var(--border); border-radius: 2px; padding: 1.25rem; margin-bottom: 1rem; }
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow-x: auto;
+}
 label { display: block; margin-top: .75rem; color: var(--muted); font-size: .85rem; }
 input, select, textarea { width: 100%; max-width: 32rem; margin-top: .25rem; padding: .45rem .5rem; border-radius: 2px; border: 1px solid var(--border); background: var(--input-bg); color: var(--text); }
 input:focus, select:focus, textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
@@ -186,7 +238,59 @@ button.btn-kill:hover { filter: brightness(0.92); }
 table { width: 100%; border-collapse: collapse; font-size: .9rem; }
 th, td { text-align: left; padding: .5rem .6rem; border-bottom: 1px solid var(--border); }
 th { color: var(--muted); font-weight: 600; }
-pre, .mono { font-family: var(--font-mono); font-size: .8rem; background: var(--input-bg); border: 1px solid var(--border); padding: .75rem; border-radius: 2px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; }
+table.audit-log-table {
+  table-layout: fixed;
+  width: 100%;
+  max-width: 100%;
+  font-size: 0.82rem;
+}
+table.audit-log-table th,
+table.audit-log-table td {
+  vertical-align: top;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+table.audit-log-table td.mono.audit-log-details {
+  font-size: 0.78rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+.audit-log-table--eng th:nth-child(1),
+.audit-log-table--eng td:nth-child(1) { width: 9.5rem; }
+.audit-log-table--eng th:nth-child(2),
+.audit-log-table--eng td:nth-child(2) { width: 7rem; }
+.audit-log-table--eng th:nth-child(3),
+.audit-log-table--eng td:nth-child(3) { width: 10rem; }
+.audit-log-table--all th:nth-child(1),
+.audit-log-table--all td:nth-child(1) { width: 9.5rem; }
+.audit-log-table--all th:nth-child(2),
+.audit-log-table--all td:nth-child(2) { width: 7rem; }
+.audit-log-table--all th:nth-child(3),
+.audit-log-table--all td:nth-child(3) { width: 9rem; }
+.audit-log-table--all th:nth-child(4),
+.audit-log-table--all td:nth-child(4) { width: 11rem; }
+pre {
+  font-family: var(--font-mono); font-size: .8rem; background: var(--input-bg); border: 1px solid var(--border);
+  padding: .75rem; border-radius: 2px; overflow-x: auto; white-space: pre-wrap; word-break: break-all;
+}
+/* .mono alone = monospace only (inputs/tables). Block “copy field” panels use div.mono. */
+.mono { font-family: var(--font-mono); }
+div.mono {
+  font-size: .8rem; background: var(--input-bg); border: 1px solid var(--border); padding: .75rem; border-radius: 2px;
+  overflow-x: auto; white-space: pre-wrap; word-break: break-all;
+}
+code {
+  font-family: var(--font-mono); font-size: .82em; padding: .12em .4em; border-radius: 3px;
+  background: var(--nav-hover); border: 1px solid var(--border); vertical-align: baseline;
+}
+details.beacon-run-host { margin-top: .75rem; padding: .35rem 0 .85rem; max-width: 100%; }
+details.beacon-run-host > summary { line-height: 1.45; }
+details.beacon-run-host ul { margin: .5rem 0 0; padding-left: 1.35rem; }
+details.beacon-run-host li { margin: .55rem 0; line-height: 1.45; }
+details.beacon-run-host li code {
+  display: block; margin-top: .35rem; font-size: .8rem; padding: .45rem .65rem; white-space: pre-wrap; word-break: break-all;
+  max-width: 100%; box-sizing: border-box;
+}
 .muted { color: var(--muted); font-size: .9rem; }
 .topo-wrap { display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-start; }
 .topo-node {
@@ -227,7 +331,7 @@ button.btn-tiny:hover { background: var(--nav-active); }
 .cmd-history-table .cmd-history-out-cell { min-width: 12rem; width: auto; }
 pre.cmd-history-out { max-height: 280px; overflow: auto; margin: 0; white-space: pre-wrap; word-break: break-word; font-size: .82rem; line-height: 1.4; }
 .cmd-page-lead { margin: 0 0 1rem; max-width: 48rem; line-height: 1.45; }
-.cmd-page-card { max-width: 60rem; }
+.cmd-page-card { max-width: 100%; }
 .cmd-beacon-row select { max-width: 100%; }
 .commands-two-col {
   display: grid;
@@ -238,6 +342,9 @@ pre.cmd-history-out { max-height: 280px; overflow: auto; margin: 0; white-space:
 }
 @media (max-width: 800px) {
   .commands-two-col { grid-template-columns: 1fr; }
+}
+@media (max-width: 640px) {
+  main { padding: 1rem 0.85rem; }
 }
 .commands-panel h3.commands-h3 {
   font-size: .95rem;
@@ -274,8 +381,11 @@ details.cmd-fold[open] summary::before { content: "▾ "; }
 ` + engagementScript + `
 </head>
 <body>
-<aside>
-  <div class="brand">ReaperC2</div>
+<aside id="reaper-nav" aria-label="Main navigation">
+  <div class="brand-row">
+    <span class="brand-title">ReaperC2</span>
+    <button type="button" class="nav-sidebar-collapse" id="nav-sidebar-collapse" aria-expanded="true" aria-controls="reaper-nav" title="Hide sidebar">«</button>
+  </div>
 ` + engagementBannerHTML + `
 ` + navItem("/engagements", "Engagements", active, "engagements") + `
 ` + navItem("/beacons", "Beacons", active, "beacons") + `
@@ -293,6 +403,7 @@ details.cmd-fold[open] summary::before { content: "▾ "; }
     <form method="post" action="/logout"><button type="submit">Sign out</button></form>
   </div>
 </aside>
+<button type="button" class="nav-sidebar-reveal" id="nav-sidebar-reveal" aria-controls="reaper-nav" title="Show sidebar">»</button>
 <main>
 <div id="toast-host" class="toast-host" aria-live="polite"></div>
 ` + bodyHTML + `
@@ -372,6 +483,27 @@ details.cmd-fold[open] summary::before { content: "▾ "; }
     });
     apply(document.documentElement.getAttribute('data-theme')||'dark');
   }
+})();
+(function(){
+  var k='` + adminNavSidebarKey + `';
+  var aside=document.getElementById('reaper-nav');
+  var collapseBtn=document.getElementById('nav-sidebar-collapse');
+  var revealBtn=document.getElementById('nav-sidebar-reveal');
+  function setCollapsed(collapsed, skipFocus){
+    document.documentElement.setAttribute('data-sidebar',collapsed?'collapsed':'expanded');
+    try{localStorage.setItem(k,collapsed?'1':'0');}catch(e){}
+    if(aside)aside.setAttribute('aria-hidden',collapsed?'true':'false');
+    if(collapseBtn)collapseBtn.setAttribute('aria-expanded',collapsed?'false':'true');
+    if(revealBtn){
+      revealBtn.hidden=!collapsed;
+      revealBtn.setAttribute('aria-hidden',collapsed?'false':'true');
+      if(collapsed&&!skipFocus)revealBtn.focus();
+    }
+  }
+  function readCollapsed(){try{return localStorage.getItem(k)==='1';}catch(e){return false;}}
+  if(collapseBtn)collapseBtn.addEventListener('click',function(){setCollapsed(true,false);});
+  if(revealBtn)revealBtn.addEventListener('click',function(){setCollapsed(false,true);if(collapseBtn)collapseBtn.focus();});
+  setCollapsed(readCollapsed(),true);
 })();
 </script>
 </main>


### PR DESCRIPTION
- Document keeping the beacon API public on port 8080 while reaching the admin UI only via kubectl port-forward or SSH local forwarding to localhost; clarify BEACON_PUBLIC_BASE_URL and ingress scope in README.
- Beacons: themed run instructions for Scythe.embedded (TERM_HARVEST=9) with readable code styling; fix global pre/.mono styles so inline code does not render as oversized blocks.
- Layout: collapsible left nav with persistence; main content uses full width next to the sidebar with responsive padding; cards clip overflowing tables.
- Audit logs (engagement and global): fixed-layout tables, wrapping details column, and export card grid that spans the content area.
- Engagements: styled assigned-operator checkboxes and tighter alignment under the label.