### PR TITLE
fix(mitreattack): Navigator export selection and cross-tactic placement

### DIFF
--- a/pkg/adminpanel/handlers_engagements.go
+++ b/pkg/adminpanel/handlers_engagements.go
@@ -950,7 +950,7 @@ func (s *Server) handleAPIEngagementAttackNavigatorLayer(w http.ResponseWriter, 
 		return
 	}
 	layer := mitreattack.NavigatorLayer(e.Name, navigatorLayerDescription(e), ver)
-	mitreattack.ApplyTechniquesToNavigatorLayer(layer, e.AttackTechniques)
+	mitreattack.ApplyTechniquesToNavigatorLayer(layer, ver, e.AttackTechniques)
 	raw, err := mitreattack.MarshalNavigatorLayer(layer)
 	if err != nil {
 		log.Printf("admin: marshal navigator layer: %v", err)

--- a/pkg/adminpanel/handlers_portal.go
+++ b/pkg/adminpanel/handlers_portal.go
@@ -1020,7 +1020,7 @@ func (s *Server) handleAPIReportsAttackNavigatorLayer(w http.ResponseWriter, r *
 		return
 	}
 	layer := mitreattack.NavigatorLayer(eng.Name, navigatorLayerDescription(eng), ver)
-	mitreattack.ApplyTechniquesToNavigatorLayer(layer, eng.AttackTechniques)
+	mitreattack.ApplyTechniquesToNavigatorLayer(layer, ver, eng.AttackTechniques)
 	raw, err := mitreattack.MarshalNavigatorLayer(layer)
 	if err != nil {
 		log.Printf("admin: marshal navigator layer (reports): %v", err)

--- a/pkg/mitreattack/navigator_expand.go
+++ b/pkg/mitreattack/navigator_expand.go
@@ -1,0 +1,122 @@
+package mitreattack
+
+import (
+	"sort"
+	"strings"
+)
+
+// tacticsContainingTechnique returns tactic keys where id appears in the matrix catalog.
+func tacticsContainingTechnique(c *EnterpriseMatrixData, id string) []string {
+	id = strings.ToUpper(strings.TrimSpace(id))
+	var out []string
+	for tac, refs := range c.ByTactic {
+		for _, r := range refs {
+			if strings.ToUpper(strings.TrimSpace(r.ID)) == id {
+				out = append(out, tac)
+				break
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func tacticOrderIndex(c *EnterpriseMatrixData) map[string]int {
+	m := make(map[string]int, len(c.Tactics))
+	for i, t := range c.Tactics {
+		m[t.Key] = i
+	}
+	return m
+}
+
+// sortTechniqueTagsForCatalogOrder sorts by embedded matrix tactic order, then technique ID.
+func sortTechniqueTagsForCatalogOrder(c *EnterpriseMatrixData, tags []TechniqueTag) {
+	order := tacticOrderIndex(c)
+	sort.Slice(tags, func(i, j int) bool {
+		oi, okI := order[tags[i].Tactic]
+		oj, okJ := order[tags[j].Tactic]
+		switch {
+		case okI && okJ && oi != oj:
+			return oi < oj
+		case okI != okJ:
+			return okI && !okJ
+		default:
+			return tags[i].TechniqueID < tags[j].TechniqueID
+		}
+	})
+}
+
+type tacticTechniqueKey struct {
+	tactic string
+	id     string
+}
+
+func mergeTechniqueTagsByTacticAndID(in []TechniqueTag) []TechniqueTag {
+	mergedNote := make(map[tacticTechniqueKey]string)
+	keyOrder := make([]tacticTechniqueKey, 0)
+	seen := make(map[tacticTechniqueKey]struct{})
+	for _, t := range in {
+		k := tacticTechniqueKey{tactic: t.Tactic, id: t.TechniqueID}
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			keyOrder = append(keyOrder, k)
+		}
+		prev := mergedNote[k]
+		note := strings.TrimSpace(t.Note)
+		switch {
+		case note == "":
+			// keep prev
+		case prev == "":
+			mergedNote[k] = note
+		case note == prev:
+			// duplicate
+		case strings.Contains(prev, note):
+			// already covered
+		default:
+			mergedNote[k] = prev + "\n\n" + note
+		}
+	}
+	out := make([]TechniqueTag, 0, len(keyOrder))
+	for _, k := range keyOrder {
+		out = append(out, TechniqueTag{
+			Tactic:      k.tactic,
+			TechniqueID: k.id,
+			Note:        mergedNote[k],
+		})
+	}
+	return out
+}
+
+// expandTagForNavigatorExport places one stored tag on every matrix tactic column that lists
+// the same technique ID (e.g. T1078.003 in Initial Access, Persistence, …). It does not add
+// sibling sub-techniques the operator did not tag.
+func expandTagForNavigatorExport(c *EnterpriseMatrixData, tag TechniqueTag) []TechniqueTag {
+	tactics := tacticsContainingTechnique(c, tag.TechniqueID)
+	if len(tactics) == 0 {
+		return []TechniqueTag{tag}
+	}
+	out := make([]TechniqueTag, 0, len(tactics))
+	for _, tac := range tactics {
+		out = append(out, TechniqueTag{Tactic: tac, TechniqueID: tag.TechniqueID, Note: tag.Note})
+	}
+	return out
+}
+
+// ExpandTechniqueTagsForNavigatorExport duplicates each tag across all tactics where that exact
+// technique ID appears in the embedded matrix for attackVersion (16–19: enterprise-{version}.json).
+func ExpandTechniqueTagsForNavigatorExport(attackVersion int, tags []TechniqueTag) ([]TechniqueTag, error) {
+	if len(tags) == 0 {
+		return nil, nil
+	}
+	c, err := EnterpriseMatrixForVersion(attackVersion)
+	if err != nil {
+		return nil, err
+	}
+	var flat []TechniqueTag
+	for i := range tags {
+		flat = append(flat, expandTagForNavigatorExport(c, tags[i])...)
+	}
+	out := mergeTechniqueTagsByTacticAndID(flat)
+	sortTechniqueTagsForCatalogOrder(c, out)
+	return out, nil
+}

--- a/pkg/mitreattack/navigator_expand_test.go
+++ b/pkg/mitreattack/navigator_expand_test.go
@@ -1,0 +1,156 @@
+package mitreattack
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+var matrixCatalogVersions = []int{16, 17, 18, 19}
+
+func TestExpandTechniqueTagsForNavigatorExport_T1078_003_allMatrixVersions(t *testing.T) {
+	for _, ver := range matrixCatalogVersions {
+		ver := ver
+		t.Run("v"+strconv.Itoa(ver), func(t *testing.T) {
+			out, err := ExpandTechniqueTagsForNavigatorExport(ver, []TechniqueTag{
+				{Tactic: "initial-access", TechniqueID: "T1078.003", Note: "got heem"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c, err := EnterpriseMatrixForVersion(ver)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := len(tacticsContainingTechnique(c, "T1078.003"))
+			if want < 1 {
+				t.Fatal("catalog should list T1078.003")
+			}
+			if len(out) != want {
+				t.Fatalf("len(out)=%d want %d (catalog tactics for T1078.003): %+v", len(out), want, out)
+			}
+			seen := make(map[string]bool)
+			for _, row := range out {
+				if row.TechniqueID != "T1078.003" {
+					t.Errorf("unexpected id %s", row.TechniqueID)
+				}
+				if row.Note != "got heem" {
+					t.Errorf("unexpected note %q", row.Note)
+				}
+				seen[row.Tactic] = true
+			}
+			if len(seen) != want {
+				t.Fatalf("tactic count: got %d want %d", len(seen), want)
+			}
+		})
+	}
+}
+
+func TestExpandTechniqueTagsForNavigatorExport_T1078_parent_allMatrixVersions(t *testing.T) {
+	for _, ver := range matrixCatalogVersions {
+		ver := ver
+		t.Run("v"+strconv.Itoa(ver), func(t *testing.T) {
+			out, err := ExpandTechniqueTagsForNavigatorExport(ver, []TechniqueTag{
+				{Tactic: "persistence", TechniqueID: "T1078", Note: "parent"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c, err := EnterpriseMatrixForVersion(ver)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := len(tacticsContainingTechnique(c, "T1078"))
+			if len(out) != want {
+				t.Fatalf("len=%d want %d: %+v", len(out), want, out)
+			}
+			for _, row := range out {
+				if row.TechniqueID != "T1078" {
+					t.Errorf("want T1078 only, got %s", row.TechniqueID)
+				}
+			}
+		})
+	}
+}
+
+func TestExpandTechniqueTagsForNavigatorExport_T1059_001_allMatrixVersions(t *testing.T) {
+	for _, ver := range matrixCatalogVersions {
+		ver := ver
+		t.Run("v"+strconv.Itoa(ver), func(t *testing.T) {
+			out, err := ExpandTechniqueTagsForNavigatorExport(ver, []TechniqueTag{
+				{Tactic: "execution", TechniqueID: "T1059.001", Note: "ps"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c, err := EnterpriseMatrixForVersion(ver)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := len(tacticsContainingTechnique(c, "T1059.001"))
+			if len(out) != want {
+				t.Fatalf("len=%d want %d: %+v", len(out), want, out)
+			}
+			for _, row := range out {
+				if row.TechniqueID != "T1059.001" || row.Note != "ps" {
+					t.Fatalf("%+v", row)
+				}
+			}
+		})
+	}
+}
+
+func TestExpandTechniqueTagsForNavigatorExport_T1005_allMatrixVersions(t *testing.T) {
+	for _, ver := range matrixCatalogVersions {
+		ver := ver
+		t.Run("v"+strconv.Itoa(ver), func(t *testing.T) {
+			out, err := ExpandTechniqueTagsForNavigatorExport(ver, []TechniqueTag{
+				{Tactic: "collection", TechniqueID: "T1005", Note: "only here"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c, err := EnterpriseMatrixForVersion(ver)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := len(tacticsContainingTechnique(c, "T1005"))
+			if len(out) != want {
+				t.Fatalf("len=%d want %d: %+v", len(out), want, out)
+			}
+			for _, row := range out {
+				if row.TechniqueID != "T1005" || row.Note != "only here" {
+					t.Fatalf("%+v", row)
+				}
+			}
+		})
+	}
+}
+
+func TestExpandTechniqueTagsForNavigatorExport_MergeSameID_allMatrixVersions(t *testing.T) {
+	for _, ver := range matrixCatalogVersions {
+		ver := ver
+		t.Run("v"+strconv.Itoa(ver), func(t *testing.T) {
+			out, err := ExpandTechniqueTagsForNavigatorExport(ver, []TechniqueTag{
+				{Tactic: "initial-access", TechniqueID: "T1078.003", Note: "a"},
+				{Tactic: "persistence", TechniqueID: "T1078.003", Note: "b"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c, err := EnterpriseMatrixForVersion(ver)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := len(tacticsContainingTechnique(c, "T1078.003"))
+			if len(out) != want {
+				t.Fatalf("len=%d want %d", len(out), want)
+			}
+			for _, row := range out {
+				if !strings.Contains(row.Note, "a") || !strings.Contains(row.Note, "b") {
+					t.Fatalf("each tactic row should merge notes; got %q for %s", row.Note, row.Tactic)
+				}
+			}
+		})
+	}
+}

--- a/pkg/mitreattack/tactics.go
+++ b/pkg/mitreattack/tactics.go
@@ -165,9 +165,10 @@ func NavigatorLayer(name, description string, attackVersion int) map[string]inte
 		"legendItems":                   []interface{}{},
 		"metadata":                      []interface{}{},
 		"links":                         []interface{}{},
-		"showTacticRowBackground":       false,
-		"selectTechniquesAcrossTactics": true,
-		"selectSubtechniquesWithParent": true,
+		"showTacticRowBackground": false,
+		// false: avoid Navigator selecting all tactic instances + all subtechniques on one click (defaults are true).
+		"selectTechniquesAcrossTactics": false,
+		"selectSubtechniquesWithParent": false,
 	}
 }
 

--- a/pkg/mitreattack/techniques.go
+++ b/pkg/mitreattack/techniques.go
@@ -141,8 +141,16 @@ func NavigatorLegendDemonstrated() map[string]interface{} {
 }
 
 // ApplyTechniquesToNavigatorLayer sets layer "techniques" and a matching legend when tags is non-empty.
-func ApplyTechniquesToNavigatorLayer(layer map[string]interface{}, tags []TechniqueTag) {
-	objs := NavigatorTechniqueLayerObjects(tags)
+// attackVersion selects the embedded matrix catalog used to place each technique ID on every tactic column where it appears.
+func ApplyTechniquesToNavigatorLayer(layer map[string]interface{}, attackVersion int, tags []TechniqueTag) {
+	if len(tags) == 0 {
+		return
+	}
+	expanded := tags
+	if ex, err := ExpandTechniqueTagsForNavigatorExport(attackVersion, tags); err == nil && len(ex) > 0 {
+		expanded = ex
+	}
+	objs := NavigatorTechniqueLayerObjects(expanded)
 	if len(objs) == 0 {
 		return
 	}


### PR DESCRIPTION
Set selectTechniquesAcrossTactics and selectSubtechniquesWithParent to false so scoring one cell does not cascade to every instance or all subtechniques.

Expand each tagged technique ID to every matrix tactic column where that ID appears in the embedded catalog for the chosen STIX version (16–19), without adding untagged sibling subtechniques.

ApplyTechniquesToNavigatorLayer now takes attackVersion for catalog-driven expansion; API handlers pass the existing query parameter.