### PR TITLE
docs: split operator guide into section pages with top nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,17 +131,20 @@ The process serves **two HTTP listeners**: the **beacon API** (implants / Scythe
 
 Operator passwords are stored as **Argon2id** (serialized in `operators.password_hash`). **Existing bcrypt hashes** (`$2a$` / `$2b$`) still verify so you can migrate gradually.
 
-Open `https://<host>:8443/beacons` (or `http://` locally; `/` redirects to **Beacons**). The UI includes:
+Open `https://<host>:8443` (or `http://` locally; `/` redirects to **Engagements**). Pick a workspace, then use **Beacons**, **Commands**, and the other operator pages. Full per-page documentation is in [`docs/operator-guide.md`](docs/operator-guide.md) and in the admin UI under **Documentation → Operator guide**.
 
 | Area | Purpose |
 |------|---------|
-| **Beacons** | Generate clients (optional **Beacon C2 base URL**: `http`/`https`, FQDN or IP, optional port — saved on the profile for embedded rebuilds). Optional label, `ParentClientId` for pivot chain, optional pivot proxy for Scythe. **Scythe Http** options in the UI match `Http` subcommand flags (`-method`, `-timeout`, `-body`, `-directories`, `-headers`, `-proxy`, `-skip-tls-verify`); **HTTP client timeout** is separate from **phone-home interval** (seconds). **Download Scythe.embedded** runs `go build` on the vendored Scythe submodule (`third_party/Scythe`; clone with `git submodule update --init`) and streams the binary — the admin host needs **Go** installed. API: `POST /api/beacons/scythe-embedded`. Each generation **always saves a profile** in `beacon_profiles`. List/delete saved profiles. |
-| **Commands** | Queue beacon tasks: strings (e.g. `whoami`, `download <host path>`) or JSON objects for Scythe file ops (`command_obj`, or stage a file with `POST /api/beacon-staging` then queue with `upload.staging_id` + `remote_path`). Heartbeat returns a JSON `Commands` array (strings and/or objects). Pulled files are stored under `REAPER_ARTIFACT_DIR` and listed/downloaded from this page (`GET /api/beacon-artifacts`, `GET /api/beacon-artifacts/{id}/file`). |
-| **Reports** | Download JSON or CSV exports (redacted or full). JSON includes `command_output` (recent beacon command results from the `data` collection). **Ghostwriter CSV** (`/api/reports/export-ghostwriter`) uses the same 13-column schema as Logs for clients, saved profiles, and command output—no operator chat (chat is under Logs). |
-| **Topology** | Graph of C2 → beacons (and parent → child when `ParentClientId` is set on a client). |
-| **Chat** | Operator messages stored in `operator_chat`. |
-| **Users** (admins only) | Create additional portal accounts and assign **Admin** or **Operator** (`/users`, `POST /api/users`). |
-| **Logs** (admins only) | View recent **audit** events (`audit_logs`): operator actions plus **beacon** deliveries (`beacon_commands_delivered`) and **output** (`beacon_output_received`). Download JSON (`/api/logs/export`, includes `operator_chat`) or **Ghostwriter CSV** (`/api/logs/export-ghostwriter`: audit + beacon results + operator chat) for Specter Ops Ghostwriter. |
+| **Engagements** | Workspaces that scope beacons, commands, reports, topology, notes, and chat; assign operators (admins). |
+| **Beacons** | Generate clients, Scythe Http options, **Scythe.embedded** download (`POST /api/beacons/scythe-embedded`; Go required on server), saved profiles, kill queue. |
+| **Commands** | Queue tasks; stage uploads; view pending queue, artifacts, and output history. |
+| **Reports** | JSON / CSV / Ghostwriter / ATT&CK Navigator layer exports. |
+| **Topology** | Interactive beacon graph (liveness + pivot chain). |
+| **Notes & ATT&CK** | Engagement notes and MITRE Navigator layer source. |
+| **Chat** | Operator chat per engagement (`operator_chat`). |
+| **Engagement logs** | Audit trail for the active engagement. |
+| **Users** (admins only) | Portal accounts (`/users`, `POST /api/users`). |
+| **All logs** (admins only) | Global audit + JSON / Ghostwriter export (includes operator chat). |
 
 **Roles** (field `operators.role` in MongoDB): **Admin** — full portal access including user management. **Operator** — beacons, reports, topology, chat, and profile management; **cannot** create users or call user APIs. Accounts without `role` are treated as **Admin** for backward compatibility. The bootstrap account is always **Admin**.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,8 @@ ReaperC2 is a C2 framework with a **beacon HTTP API** and an **operator admin pa
 | Topic | Description |
 |-------|-------------|
 | [Installation](/documentation/installation) | Prerequisites, building from source, MongoDB seeding |
-| [Usage](/documentation/usage) | Environment variables, listeners, operator UI overview |
+| [Usage](/documentation/usage) | Environment variables, listeners, operator UI summary |
+| [Operator guide](/documentation/operator-guide) | What each admin page does (Engagements, Beacons, Commands, …) |
 | [Docker Compose](/documentation/docker-compose) | Local full stack with MongoDB |
 | [Kubernetes](/documentation/kubernetes) | Cluster deployment, manifests, admin access patterns |
 

--- a/docs/operator-guide-account.md
+++ b/docs/operator-guide-account.md
@@ -1,0 +1,10 @@
+# Account
+
+**Path:** `/account`
+
+Available to any signed-in operator. Does not require an active engagement.
+
+- **Password** — Change password (minimum length enforced server-side).
+- **Two-factor authentication (TOTP)** — Optional Google Authenticator–compatible 2FA: set up (QR + verify), or disable (requires current password).
+
+If 2FA is enabled, login continues at `/login/mfa` after username/password.

--- a/docs/operator-guide-all-logs.md
+++ b/docs/operator-guide-all-logs.md
@@ -1,0 +1,13 @@
+# All logs
+
+**Path:** `/logs`  
+**Requires:** Admin role
+
+Global audit log across engagements plus events such as user creation and full exports. Includes an **Engagement** column when applicable.
+
+| Export | Contents |
+|--------|----------|
+| **Full audit log (JSON)** | Up to 50k entries + `operator_chat` |
+| **Ghostwriter CSV** | Audit + beacon results + operator chat (Specter Ops import) |
+
+For a single engagement, operators use **Engagement logs**.

--- a/docs/operator-guide-beacons.md
+++ b/docs/operator-guide-beacons.md
@@ -1,0 +1,111 @@
+# Beacons
+
+**Path:** `/beacons`  
+**Requires:** Active engagement
+
+Beacons is where you **register implant identities** against the C2 server, configure how **Scythe** (or compatible HTTP beacons) phone home, download **Scythe.embedded** binaries, and manage saved **profiles**. Generating a beacon creates:
+
+1. A row in MongoDB **`clients`** (what the implant authenticates with on heartbeat).
+2. A **`beacon_profiles`** record (always saved) with the full generation metadata for reports and re-downloads.
+
+## Tabs
+
+| Tab | Purpose |
+|-----|---------|
+| **Generate beacon** | Create a new client + profile in one step |
+| **Saved profiles** | List, copy credentials, rebuild embedded binary, kill, or delete profiles |
+
+Use URL hash `#profiles` (or **Refresh profile list**) to jump to saved profiles after a page reload.
+
+## Generate beacon — fields
+
+**Display label**  
+Optional friendly name shown on **Topology**, **Commands** beacon picker, and exports. Does not affect authentication.
+
+**Parent beacon ClientId**  
+Optional UUID of an **upstream** beacon for a **pivot chain**. When set, Scythe examples include `--proxy` (see pivot proxy). Topology draws parent → child edges toward C2.
+
+**Pivot proxy `host:port`**  
+Used in Scythe `--proxy` when a parent is set (unless overridden in Scythe Http **Proxy**). Server default: environment `BEACON_PIVOT_PROXY`.
+
+**Beacon C2 base URL**  
+Public origin implants should call (e.g. `https://c2.example.com` or `10.0.0.5:8080`). Saved on the profile for embedded rebuilds. Server default: `BEACON_PUBLIC_BASE_URL`.  
+**Important:** This is the **beacon listener** (usually port **8080**), not the admin UI on **8443**.
+
+**Expected phone-home interval (seconds)**  
+Operator-defined check-in window (5–86400, default 60). **Topology** uses this for status: **green** = on time, **yellow** = missed one interval, **gray** = offline or unknown.
+
+**Profile name**  
+Optional; otherwise auto-named `beacon-xxxxxxxx-YYYYMMDD-hhmmss`. A profile is **always** persisted even if you leave this blank.
+
+## Scythe Http (collapsible)
+
+These options build the example **`Scythe Http …`** command and the embedded compile. They map to Scythe CLI flags.
+
+| Field | Scythe flag / behavior |
+|-------|-------------------------|
+| HTTP method | `-method` (default `GET`) |
+| HTTP client timeout | `-timeout` (e.g. `30s`) — **not** the phone-home interval |
+| Request body | `-body` (optional JSON string) |
+| Extra directories | Appended after required `/heartbeat/<ClientId>,/heartbeat` |
+| Extra headers | Merged after required `Content-Type`, `X-Client-Id`, `X-API-Secret` |
+| Proxy | `-proxy`; pivot proxy fills in when parent is set and this is empty |
+| SOCKS5 listener | `-socks5-listen` / `-socks5-port` |
+| Skip TLS verify | `-skip-tls-verify` |
+| GOOS / GOARCH | Target for **Scythe.embedded** (`linux`/`windows`/`darwin`, `amd64`/`arm64`) |
+
+After **Generate beacon**, the JSON response is shown on the page (ClientId, secret, heartbeat URL, Scythe example). Open **Saved profiles** → **View credentials** to copy values after refresh.
+
+## Generate beacon — actions
+
+**Generate beacon** — `POST /api/beacons` with `connection_type: HTTP` and your form values.
+
+**Download Scythe.embedded** (after successful generate) — `POST /api/beacons/scythe-embedded`. The server runs `go build` on vendored Scythe (`third_party/Scythe` or `REAPERC2_ROOT`). Requires **Go on the admin host**. Build often takes 30s–2m; progress is shown while downloading.
+
+**Run embedded binary on the host**  
+Embedded Scythe requires environment variable **`TERM_HARVEST=9`** before start (see collapsible help on the page). Examples:
+
+```bash
+export TERM_HARVEST=9 && ./Scythe
+```
+
+```powershell
+$env:TERM_HARVEST='9'; .\Scythe.exe
+```
+
+## Saved profiles — table
+
+| Column | Meaning |
+|--------|---------|
+| Name | Profile label |
+| Client ID | Beacon UUID |
+| Type | Connection type (e.g. HTTP) |
+| Created by | Operator who generated it |
+
+**View credentials** — Client ID, secret, label, parent, pivot proxy, expected interval, embedded target OS/arch, beacon base URL, heartbeat URL, full Scythe example (copy buttons).
+
+**Scythe.embedded** — Rebuild and download using the profile’s **saved** Http options (no need to re-enter the form).
+
+**Kill** — Queues Scythe self-destruct command `sendmetojesusdog` on the next heartbeat (`POST /api/beacon-kill`). Confirm before use.
+
+**Delete** — Removes the **profile** record only (`DELETE /api/beacon-profiles/{id}`). Does not automatically remove the live `clients` row; the implant may still check in until removed or killed.
+
+## How a beacon talks to C2
+
+Typical Scythe HTTP flow (simplified):
+
+1. **GET** `/heartbeat/<ClientId>` (and related paths) with headers `X-Client-Id`, `X-API-Secret`.
+2. Response may include a JSON **`Commands`** array (strings and/or objects).
+3. Beacon runs tasks and **POST**s output to `/receive/<ClientId>`.
+
+Queue work from **Commands**; results appear in output history and audit logs.
+
+## Beacon troubleshooting
+
+| Issue | Check |
+|-------|--------|
+| Implant cannot connect | `BEACON_PUBLIC_BASE_URL` / per-beacon base URL points at **8080** (or your public ingress to it), not admin **8443** |
+| Embedded won’t start | `TERM_HARVEST=9` set in the same shell/session |
+| Embedded build fails | Go installed on server; Scythe sources at `third_party/Scythe` or `REAPERC2_ROOT` |
+| No beacons on Commands page | Generate under **Beacons** for the **active** engagement |
+| Topology all gray | Beacon never checked in, or interval much shorter than actual sleep |

--- a/docs/operator-guide-chat.md
+++ b/docs/operator-guide-chat.md
@@ -1,0 +1,8 @@
+# Chat
+
+**Path:** `/chat`  
+**Requires:** Active engagement
+
+Operator-only chat for the engagement. Messages are stored in MongoDB `operator_chat`. The room key comes from the engagement’s **Slack / Discord room** field, or a stable internal id if unset.
+
+The log **polls** every few seconds; new messages appear after **Send** (`POST /api/chat/messages`). Chat is included in **All logs** JSON / Ghostwriter exports, not in **Reports** JSON.

--- a/docs/operator-guide-commands.md
+++ b/docs/operator-guide-commands.md
@@ -1,0 +1,35 @@
+# Commands
+
+**Path:** `/commands`  
+**Requires:** Active engagement
+
+Queue tasks for beacons in the current engagement and review pending work, staged files, downloads, and output history.
+
+## Shell / Scythe command
+
+1. Select a **beacon** (label + Client ID).
+2. Optionally pick a **preset**: `whoami`, `groups`, `environment`, `kube-auth-can-i-list`, or `download` (appends `download ` for a host path).
+3. Enter a **command**:
+   - Plain text → queued as a string (e.g. `whoami`, `download C:\Windows\Temp\file.txt`).
+   - JSON object → Scythe structured ops (`command_obj`), e.g. upload metadata.
+4. **Queue command** — `POST /api/beacon-commands`.
+
+Pending commands are delivered on the beacon’s next **`GET /heartbeat/<uuid>`**.
+
+## Upload file to beacon
+
+1. Choose a local file → **Stage on server** (`POST /api/beacon-staging`) → receive a staging ID.
+2. Set **remote path** on the target (trailing `/` or `\` uses the staged file name).
+3. **Queue upload** — sends JSON such as `upload` with `staging_id` and `remote_path`.
+
+## Pending queue
+
+Shows all engagement beacons and commands waiting for the next heartbeat. **Refresh** reloads from `GET /api/beacon-commands`.
+
+## Files
+
+Lists **file artifacts**: operator-staged uploads and files **downloaded from beacons** via the `download` built-in. Stored under `REAPER_ARTIFACT_DIR` (default `./data/reaper_artifacts`). Download via `GET /api/beacon-artifacts/{id}/file`.
+
+## Output history
+
+Per selected beacon: stored command output from the `data` collection. **Load history** / **Refresh** via the commands page API.

--- a/docs/operator-guide-engagement-logs.md
+++ b/docs/operator-guide-engagement-logs.md
@@ -1,0 +1,12 @@
+# Engagement logs
+
+**Path:** `/engagement/logs`  
+**Requires:** Active engagement  
+**Nav:** Shown in the sidebar when a workspace is active
+
+Audit trail **for this engagement only**: beacon command delivery, output received, queued commands, report exports, etc.
+
+- **Download this engagement (JSON)** — up to 50k newest audit rows.
+- **Recent (500)** — table of time, actor, action, details (truncated in UI; full text in export).
+
+Admins can also use **All logs** for cross-engagement view.

--- a/docs/operator-guide-engagements.md
+++ b/docs/operator-guide-engagements.md
@@ -1,0 +1,29 @@
+# Engagements
+
+**Path:** `/engagements`
+
+Engagements are the top-level container for an operation. Everything under **Beacons**, **Commands**, **Reports**, **Topology**, **Notes & ATT&CK**, **Chat**, and **Engagement logs** is filtered to the **active workspace**.
+
+## Your engagements
+
+Lists **open** engagements you may access (operators see only engagements where they are in **Assigned operators**; admins see all).
+
+| Column | Meaning |
+|--------|---------|
+| Name | Engagement title |
+| Client | Customer / org display name |
+| Start / End | Planned dates (reporting) |
+| Haul | **Interactive**, **Short Haul**, or **Long Haul** (planning category) |
+| Operators | Usernames assigned to the engagement |
+
+**Workspace** — Sets this engagement as the active workspace and takes you to operator pages (banner at top of nav shows the current engagement).
+
+**Manage** — Opens a dialog to change **status** (open/closed), **haul type**, and (admins only) **assigned operators**. General notes and MITRE fields are on **Notes & ATT&CK**, not in this dialog.
+
+## Archived engagements
+
+Closed engagements appear here. Filter by client name substring, then **Workspace** or **Manage** (re-open by setting status back to **open**).
+
+## Create engagement
+
+Fill name, client, dates, haul type, optional **Slack / Discord room** (used as the chat room key), initial notes, and operator checkboxes. The creator is typically included in assigned operators.

--- a/docs/operator-guide-notes.md
+++ b/docs/operator-guide-notes.md
@@ -1,0 +1,18 @@
+# Notes & ATT&CK
+
+**Path:** `/notes`  
+**Requires:** Active engagement
+
+Engagement-scoped documentation and MITRE mapping for reporting.
+
+## Engagement notes
+
+Free-form text (scope, handoff, contacts). Not sent to beacons. Saved with **Save** (`PATCH /api/engagements/{id}`).
+
+## MITRE ATT&CK
+
+- **Tactic notes** — One textarea per enterprise tactic (matrix version selector drives tactic/technique menus; v19 adds tactics such as **Stealth** and **Defense Impairment**).
+- **Technique tags** — Rows of tactic + technique + optional note. Exported to Navigator as green highlights (`#74c476`) with per-technique comments.
+- **Matrix (STIX) version** — Must match the ATT&CK release you use in [ATT&CK Navigator](https://mitre-attack.github.io/attack-navigator/). **Download Navigator layer JSON** uses the same version for catalog placement (each tagged technique ID is repeated on every matrix tactic column where that ID appears).
+
+Status, haul type, and operator assignment remain under **Engagements → Manage**.

--- a/docs/operator-guide-reports.md
+++ b/docs/operator-guide-reports.md
@@ -1,0 +1,15 @@
+# Reports
+
+**Path:** `/reports`  
+**Requires:** Active engagement
+
+Export snapshots for briefings. Secrets can be redacted for wider distribution.
+
+| Export | Contents |
+|--------|----------|
+| **JSON (redacted / full)** | Engagement metadata, clients, saved profiles, recent `command_output` (newest 5000 rows). Full JSON includes profile secrets and raw output. |
+| **CSV (redacted)** | Clients table only (spreadsheet-friendly). Use JSON for full command history. |
+| **Ghostwriter CSV** | Specter Ops 13-column schema: clients, profiles, beacon command output (same as Logs Ghostwriter export for this data). |
+| **MITRE ATT&CK Navigator layer JSON** | Built from **Notes & ATT&CK** (tactic notes, technique tags, general notes). Choose **STIX version** (v16–v19) to match your Navigator bundle; download via `GET /api/reports/attack-navigator-layer`. |
+
+Operator chat is **not** in Reports JSON; use **Logs** exports for chat.

--- a/docs/operator-guide-topology.md
+++ b/docs/operator-guide-topology.md
@@ -1,0 +1,17 @@
+# Topology
+
+**Path:** `/topology`  
+**Requires:** Active engagement
+
+Interactive **graph** of C2 → beacons (and parent → child when `ParentClientId` is set). Data from `GET /api/topology`.
+
+| Color | Meaning |
+|-------|---------|
+| **Blue** | C2 server node |
+| **Green** | Beacon on time (within expected interval) |
+| **Yellow** | Late (missed expected interval) |
+| **Gray** | Offline / stale, or reference node |
+
+Drag to rearrange, scroll to zoom, hover for details. Arrows point along the path **toward C2**. **Refresh** reloads layout and status; **Export PNG** saves the canvas.
+
+Set **Expected phone-home interval** on **Beacons** so late/offline coloring matches your operational cadence.

--- a/docs/operator-guide-users.md
+++ b/docs/operator-guide-users.md
@@ -1,0 +1,8 @@
+# Users
+
+**Path:** `/users`  
+**Requires:** Admin role
+
+Create portal accounts and assign **Admin** or **Operator**. Enable/disable accounts (disabled users cannot sign in). Admins cannot disable themselves from the list actions.
+
+API: `POST /api/users` and related user management endpoints. Operators do not see this page.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -1,0 +1,51 @@
+# Operator guide
+
+This guide describes each page in the ReaperC2 **admin panel** (default `http://127.0.0.1:8443`). The **beacon API** (default `:8080`) is what implants call; operators use the web UI to manage engagements, generate beacons, queue commands, and export reporting data.
+
+Use the **section tabs** above to open Engagements, Beacons, Commands, and the rest of the portal pages.
+
+## Before you start
+
+| Concept | Meaning |
+|---------|---------|
+| **Engagement** | A workspace (customer assessment) that scopes beacons, commands, topology, notes, chat, and reports. |
+| **Active workspace** | The engagement you selected with **Workspace** on the Engagements page. Most nav items require one. |
+| **Beacon / client** | One implant identity: a UUID (`ClientId`) plus API secret, stored in MongoDB `clients` and linked to an engagement. |
+| **Profile** | A saved generation record in `beacon_profiles` (credentials, Scythe CLI example, Http options) for reuse and exports. |
+
+**Roles**
+
+- **Admin** — Full portal access, including **Users** and **All logs**.
+- **Operator** — Beacons, commands, reports, topology, notes, chat, engagement logs; cannot manage portal users.
+
+**Documentation** in the left nav does not require an active workspace. **Engagements** is the home page after login (`/` redirects there).
+
+## Quick reference — which page do I use?
+
+| Goal | Page |
+|------|------|
+| Start or switch customer workspace | **Engagements** → **Workspace** |
+| Create implant credentials / download binary | **Beacons** |
+| Run `whoami`, upload file, `download` from host | **Commands** |
+| Briefing export / Navigator layer | **Reports** / **Notes & ATT&CK** |
+| See pivot chain and liveness | **Topology** |
+| Team coordination | **Chat** |
+| Investigate what happened | **Engagement logs** (or **All logs** for admins) |
+| Add operator account | **Users** (admin) |
+| Change password or enable 2FA | **Account** |
+
+## Sections
+
+| Section | Admin path |
+|---------|------------|
+| [Engagements](/documentation/operator-guide-engagements) | `/engagements` |
+| [Beacons](/documentation/operator-guide-beacons) | `/beacons` |
+| [Commands](/documentation/operator-guide-commands) | `/commands` |
+| [Reports](/documentation/operator-guide-reports) | `/reports` |
+| [Topology](/documentation/operator-guide-topology) | `/topology` |
+| [Notes & ATT&CK](/documentation/operator-guide-notes) | `/notes` |
+| [Chat](/documentation/operator-guide-chat) | `/chat` |
+| [Engagement logs](/documentation/operator-guide-engagement-logs) | `/engagement/logs` |
+| [All logs](/documentation/operator-guide-all-logs) | `/logs` (admins) |
+| [Users](/documentation/operator-guide-users) | `/users` (admins) |
+| [Account](/documentation/operator-guide-account) | `/account` |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,27 +15,33 @@ Set `ADMIN_DISABLE=1` to run **beacon only** (no web UI on that instance).
 
 Open the admin URL (for example `http://127.0.0.1:8443/login`). Use an account from the `operators` collection or the bootstrap credentials on first run.
 
-After login, pick an **Engagement** workspace (required for most operator pages). **Documentation** is available without switching context.
+After login, open **Engagements** and choose **Workspace** on an engagement. Most operator pages require an **active workspace** (banner in the sidebar). **Documentation** and **Account** work without one.
 
-## Operator UI (summary)
+## Operator UI
+
+For a full walkthrough of every admin page (especially **Beacons**), see **[Operator guide](/documentation/operator-guide)**.
 
 | Area | Purpose |
 |------|---------|
-| **Engagements** | Create and manage engagements; admins assign operators |
-| **Beacons** | Generate client profiles, Scythe examples, **Scythe.embedded** download |
-| **Commands** | Queue shell / Scythe tasks; view artifacts |
-| **Reports** | JSON / CSV exports |
-| **Topology** | Beacon graph |
-| **Notes & ATT&CK** | Engagement notes and MITRE layer |
-| **Chat** | Operator chat room |
-| **Users** / **Logs** | Admin-only user and audit views |
+| **Engagements** | Create workspaces; assign operators; open/close engagements |
+| **Beacons** | Generate clients, Scythe examples, **Scythe.embedded** download, profiles, kill |
+| **Commands** | Queue shell / Scythe tasks; stage uploads; view artifacts and output |
+| **Reports** | JSON / CSV / Ghostwriter / ATT&CK Navigator layer exports |
+| **Topology** | Interactive beacon graph (liveness and pivot chain) |
+| **Notes & ATT&CK** | Engagement notes and MITRE Navigator layer source data |
+| **Chat** | Operator chat per engagement |
+| **Engagement logs** | Audit trail for the active engagement |
+| **All logs** | Admin-only global audit + exports |
+| **Users** | Admin-only portal accounts |
+| **Account** | Password and optional TOTP 2FA |
 
-Roles: **Admin** (full access) vs **Operator** (no user APIs). See repository README for API details.
+Roles: **Admin** (full access) vs **Operator** (no user APIs). Legacy accounts without `role` are treated as Admin.
 
 ## Beacon / Scythe
 
-- Set **Beacon C2 base URL** in the UI (or `BEACON_PUBLIC_BASE_URL`) to the **public** origin beacons use (not `localhost:8443`).
-- **Scythe.embedded** requires **Go** on the server host (or container) at runtime; sources resolve via `REAPERC2_ROOT/third_party/Scythe` or submodule path next to the binary.
+- Set **Beacon C2 base URL** in the UI (or `BEACON_PUBLIC_BASE_URL`) to the **public** origin beacons use (port **8080** / ingress to beacon API — not `localhost:8443` admin).
+- **Scythe.embedded** requires **Go** on the server host at runtime; sources resolve via `REAPERC2_ROOT/third_party/Scythe` or submodule path next to the binary.
+- Embedded binaries need **`TERM_HARVEST=9`** in the environment before launch (see **Beacons** page in the UI or Operator guide).
 
 ## Security-related environment variables
 
@@ -47,6 +53,7 @@ Roles: **Admin** (full access) vs **Operator** (no user APIs). See repository RE
 
 ## Further reading
 
+- [Operator guide](/documentation/operator-guide) — per-page UI reference
 - [Installation](/documentation/installation)
 - [Docker Compose](/documentation/docker-compose)
 - [Kubernetes](/documentation/kubernetes)

--- a/pkg/adminpanel/handlers_docs.go
+++ b/pkg/adminpanel/handlers_docs.go
@@ -14,16 +14,32 @@ import (
 	"github.com/yuin/goldmark/renderer/html"
 )
 
-var docPages = []struct {
-	Slug string // URL segment under /documentation (empty = index)
-	File string // filename in docs/
-	Name string // sidebar label
-}{
-	{"", "README.md", "Overview"},
-	{"installation", "installation.md", "Installation"},
-	{"usage", "usage.md", "Usage"},
-	{"docker-compose", "docker-compose.md", "Docker Compose"},
-	{"kubernetes", "kubernetes.md", "Kubernetes"},
+type docPageDef struct {
+	Slug    string // URL segment under /documentation (empty = index)
+	File    string // filename in docs/
+	Name    string // label in sidebar / operator-guide top nav
+	Sidebar bool   // show in left documentation nav
+	OpGuide bool   // show operator-guide top nav when viewing this page
+}
+
+var docPages = []docPageDef{
+	{"", "README.md", "Overview", true, false},
+	{"installation", "installation.md", "Installation", true, false},
+	{"usage", "usage.md", "Usage", true, false},
+	{"operator-guide", "operator-guide.md", "Operator guide", true, true},
+	{"operator-guide-engagements", "operator-guide-engagements.md", "Engagements", false, true},
+	{"operator-guide-beacons", "operator-guide-beacons.md", "Beacons", false, true},
+	{"operator-guide-commands", "operator-guide-commands.md", "Commands", false, true},
+	{"operator-guide-reports", "operator-guide-reports.md", "Reports", false, true},
+	{"operator-guide-topology", "operator-guide-topology.md", "Topology", false, true},
+	{"operator-guide-notes", "operator-guide-notes.md", "Notes & ATT&CK", false, true},
+	{"operator-guide-chat", "operator-guide-chat.md", "Chat", false, true},
+	{"operator-guide-engagement-logs", "operator-guide-engagement-logs.md", "Engagement logs", false, true},
+	{"operator-guide-all-logs", "operator-guide-all-logs.md", "All logs", false, true},
+	{"operator-guide-users", "operator-guide-users.md", "Users", false, true},
+	{"operator-guide-account", "operator-guide-account.md", "Account", false, true},
+	{"docker-compose", "docker-compose.md", "Docker Compose", true, false},
+	{"kubernetes", "kubernetes.md", "Kubernetes", true, false},
 }
 
 var goldmarkRenderer = goldmark.New(
@@ -33,14 +49,98 @@ var goldmarkRenderer = goldmark.New(
 	),
 )
 
-func docPageBySlug(slug string) (file, title string, ok bool) {
+func docPageBySlug(slug string) (docPageDef, bool) {
 	for _, p := range docPages {
 		if p.Slug == slug {
-			return p.File, p.Name, true
+			return p, true
 		}
 	}
-	return "", "", false
+	return docPageDef{}, false
 }
+
+func docHref(slug string) string {
+	if slug == "" {
+		return "/documentation"
+	}
+	return "/documentation/" + slug
+}
+
+func buildDocSidebarNav(activeSlug string) string {
+	var nav strings.Builder
+	nav.WriteString(`<nav class="doc-nav" aria-label="Documentation pages"><ul>`)
+	for _, p := range docPages {
+		if !p.Sidebar {
+			continue
+		}
+		href := docHref(p.Slug)
+		liClass := ""
+		if p.Slug == activeSlug || (p.Slug == "operator-guide" && strings.HasPrefix(activeSlug, "operator-guide")) {
+			liClass = ` class="doc-nav-active"`
+		}
+		nav.WriteString(fmt.Sprintf(`<li%s><a href="%s">%s</a></li>`,
+			liClass, template.HTMLEscapeString(href), template.HTMLEscapeString(p.Name)))
+	}
+	nav.WriteString(`</ul></nav>`)
+	return nav.String()
+}
+
+func buildOperatorGuideTopNav(activeSlug string) string {
+	var nav strings.Builder
+	nav.WriteString(`<nav class="op-guide-top-nav" aria-label="Operator guide sections"><ul>`)
+	for _, p := range docPages {
+		if !p.OpGuide {
+			continue
+		}
+		href := docHref(p.Slug)
+		liClass := ""
+		if p.Slug == activeSlug {
+			liClass = ` class="op-guide-top-nav-active"`
+		}
+		nav.WriteString(fmt.Sprintf(`<li%s><a href="%s">%s</a></li>`,
+			liClass, template.HTMLEscapeString(href), template.HTMLEscapeString(p.Name)))
+	}
+	nav.WriteString(`</ul></nav>`)
+	return nav.String()
+}
+
+const docOpGuideStyles = `
+<style>
+.op-guide-top-nav {
+  margin: 0 0 1rem;
+  padding: 0 0 0.65rem;
+  border-bottom: 1px solid var(--border);
+}
+.op-guide-top-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.5rem;
+}
+.op-guide-top-nav li { margin: 0; }
+.op-guide-top-nav a {
+  display: inline-block;
+  padding: 0.35rem 0.65rem;
+  border-radius: 2px;
+  font-size: 0.88rem;
+  color: var(--muted);
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+.op-guide-top-nav a:hover {
+  color: var(--accent);
+  border-color: var(--border);
+  background: var(--nav-hover);
+}
+.op-guide-top-nav li.op-guide-top-nav-active a {
+  color: var(--text);
+  font-weight: 600;
+  border-color: var(--accent-dim);
+  background: var(--nav-active);
+}
+</style>
+`
 
 func (s *Server) handleDocumentationGET(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -55,19 +155,16 @@ func (s *Server) handleDocumentationGET(w http.ResponseWriter, r *http.Request) 
 	slug := path
 	if slug == "" {
 		slug = ""
-	} else {
-		// Reject odd paths (no directory traversal)
-		if strings.Contains(slug, "..") || strings.Contains(slug, "/") {
-			http.NotFound(w, r)
-			return
-		}
+	} else if strings.Contains(slug, "..") || strings.Contains(slug, "/") {
+		http.NotFound(w, r)
+		return
 	}
-	file, pageTitle, ok := docPageBySlug(slug)
+	page, ok := docPageBySlug(slug)
 	if !ok {
 		http.NotFound(w, r)
 		return
 	}
-	raw, err := docs.Markdown.ReadFile(file)
+	raw, err := docs.Markdown.ReadFile(page.File)
 	if err != nil {
 		http.Error(w, "documentation not available", http.StatusInternalServerError)
 		return
@@ -77,35 +174,38 @@ func (s *Server) handleDocumentationGET(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "failed to render documentation", http.StatusInternalServerError)
 		return
 	}
-	var nav strings.Builder
-	nav.WriteString(`<nav class="doc-nav" aria-label="Documentation pages"><ul>`)
-	for _, p := range docPages {
-		href := "/documentation"
-		if p.Slug != "" {
-			href += "/" + p.Slug
-		}
-		liClass := ""
-		if p.Slug == slug {
-			liClass = ` class="doc-nav-active"`
-		}
-		nav.WriteString(fmt.Sprintf(`<li%s><a href="%s">%s</a></li>`,
-			liClass, template.HTMLEscapeString(href), template.HTMLEscapeString(p.Name)))
+
+	sidebar := buildDocSidebarNav(slug)
+	opGuideNav := ""
+	if page.OpGuide {
+		opGuideNav = docOpGuideStyles + buildOperatorGuideTopNav(slug)
 	}
-	nav.WriteString(`</ul></nav>`)
 
 	title := "Documentation"
-	if slug != "" {
-		title = pageTitle + " — Documentation"
+	switch {
+	case page.OpGuide && page.Slug == "operator-guide":
+		title = "Operator guide — Documentation"
+	case page.OpGuide:
+		title = page.Name + " — Operator guide"
+	case slug != "":
+		title = page.Name + " — Documentation"
 	}
+
+	lead := `<p class="muted doc-lead">Operator guides (same Markdown as the <code>docs/</code> folder in the repository).</p>`
+	if page.OpGuide {
+		lead = `<p class="muted doc-lead">Per-page reference for the ReaperC2 admin panel. Pick a section below or use the left nav to return to other documentation topics.</p>`
+	}
+
 	body := fmt.Sprintf(`
 <div class="doc-page">
   <h1>Documentation</h1>
-  <p class="muted doc-lead">Operator guides (same Markdown as the <code>docs/</code> folder in the repository).</p>
+  %s
+  %s
   <div class="doc-layout">
     %s
     <article class="doc-body doc-card card">%s</article>
   </div>
-</div>`, nav.String(), htmlBuf.String())
+</div>`, lead, opGuideNav, sidebar, htmlBuf.String())
 
 	s.writeAppPage(w, user, role, "documentation", title, body, nil)
 }


### PR DESCRIPTION
Add per-page Markdown for Engagements, Beacons, Commands, and other admin areas, with a landing page at /documentation/operator-guide. Render a section top nav in the admin UI and keep a single Operator guide entry in the documentation sidebar.

Update README and usage docs to point at the new guide structure.