### PR TITLE
Add AWS admin bootstrap secret and Bedrock IRSA for EKS.

### DIFF
--- a/deployments/k8s/AWS/README.md
+++ b/deployments/k8s/AWS/README.md
@@ -33,12 +33,14 @@ From the **repo root**, after [`make build`](#build-and-push):
 cd deployments/k8s/AWS
 cp examples/documentdb-secret.yaml examples/documentdb-secret.local.yaml
 cp examples/documentdb-admin-secret.yaml examples/documentdb-admin-secret.local.yaml
+cp examples/admin-bootstrap-secret.yaml examples/admin-bootstrap-secret.local.yaml
 ```
 
 Edit:
 
 - `examples/documentdb-secret.local.yaml` — host, `username`, `password`, `database`, **`auth_source` (same as `database`)**
 - `examples/documentdb-admin-secret.local.yaml` — DocumentDB **master** user (init Job only)
+- `examples/admin-bootstrap-secret.local.yaml` — first **admin UI** login (only when `operators` collection is empty)
 - `deployment.yaml` — ECR `image:` tag you pushed
 - `ingress.yaml` / `ingressroute.yaml` — beacon hostname
 
@@ -54,6 +56,7 @@ chmod +x fetch-docdb-ca-bundle.sh && ./fetch-docdb-ca-bundle.sh
 kubectl apply -f namespace.yaml
 kubectl apply -f examples/documentdb-secret.local.yaml
 kubectl apply -f examples/documentdb-admin-secret.local.yaml
+kubectl apply -f examples/admin-bootstrap-secret.local.yaml
 
 # ECR pull (replace ACCOUNT / region)
 kubectl create secret docker-registry reaperc2-myregistrykey \
@@ -158,8 +161,9 @@ Then set `deployment.yaml` `image:` to the tag you pushed (e.g. `123456789012.dk
 | ECR image URI | `deployment.yaml` → `spec.template.spec.containers[0].image` |
 | Beacon hostname / TLS | `ingress.yaml`, `ingressroute.yaml` → `subdomain.domain.com` |
 | DocumentDB host, user, password | `examples/documentdb-secret.local.yaml` (from template; not committed) |
+| Admin UI first login | `examples/admin-bootstrap-secret.local.yaml` → Secret `reaperc2-admin-bootstrap` |
 | ECR pull secret | `examples/registry-secret.yaml` (commands only) |
-| Operator AI (Bedrock, etc.) | `ai-config.yaml` + Secret `reaperc2-ai-secrets` |
+| Operator AI (Bedrock, etc.) | `ai-config.yaml` + IRSA on ServiceAccount `reaperc2` (or `reaperc2-ai-secrets`) |
 
 ## Deploy (details)
 
@@ -172,7 +176,9 @@ Use the [checklist](#run-from-scratch-checklist) order. Notes:
 
 `kubectl apply -k .` applies ReaperC2, ingress, `reaperc2-ai-config` (Bedrock by default), and DocumentDB init scripts.
 
-**Operator AI:** edit `ai-config.yaml` (region, model IDs), then create `reaperc2-ai-secrets` with API keys or use Bedrock IAM/IRSA. Do **not** apply the root [`operator-ai.yaml`](../operator-ai.yaml) ConfigMap — it would overwrite this bundle’s `ai-config.yaml`.
+**Operator AI:** edit `ai-config.yaml` (region, model IDs), then configure Bedrock via **IRSA** ([`examples/bedrock-irsa.md`](examples/bedrock-irsa.md)) or `reaperc2-ai-secrets` API keys. Do **not** apply the root [`operator-ai.yaml`](../operator-ai.yaml) ConfigMap — it would overwrite this bundle’s `ai-config.yaml`.
+
+**Admin UI login** is **not** DocumentDB. On first boot (empty `operators` collection), use `username` / `password` from `reaperc2-admin-bootstrap`. Change the password after login or create operators in MongoDB and remove the bootstrap secret.
 
 ```bash
 kubectl create secret generic reaperc2-ai-secrets -n reaperc2-ns \
@@ -220,6 +226,10 @@ REAPER_AI_BEDROCK_USE_IAM: "1"
 ```
 
 Remove Bedrock keys from `reaperc2-ai-secrets`, `kubectl apply -k .`, and restart once. The AWS SDK uses the pod role; EKS refreshes the web identity token automatically.
+
+Step-by-step IRSA setup: [`examples/bedrock-irsa.md`](examples/bedrock-irsa.md). Example IAM policy: [`examples/bedrock-iam-policy.json`](examples/bedrock-iam-policy.json).
+
+**Troubleshooting — `AccessDeniedException` on `bedrock:InvokeModel` with the EKS *node group* role in the error:** the pod is using the **node instance profile**, not IRSA. Fix: create the Bedrock policy + `eksctl create iamserviceaccount` (or annotate `serviceaccount.yaml` with `eks.amazonaws.com/role-arn`), ensure `REAPER_AI_BEDROCK_USE_IAM=1`, rollout restart, and confirm `AWS_ROLE_ARN` is set in the pod. Alternatively, put a Bedrock API key in `reaperc2-ai-secrets` (see [`operator-ai.yaml`](../operator-ai.yaml)).
 
 If you previously deployed in-cluster Ollama, remove leftovers:
 

--- a/deployments/k8s/AWS/ai-config.yaml
+++ b/deployments/k8s/AWS/ai-config.yaml
@@ -12,7 +12,8 @@ data:
   # AWS Bedrock (prefer IRSA: REAPER_AI_BEDROCK_USE_IAM=1 on the ReaperC2 ServiceAccount when configured)
   REAPER_AI_BEDROCK_ENABLED: "1"
   REAPER_AI_BEDROCK_REGION: "us-east-1"
-  # REAPER_AI_BEDROCK_USE_IAM: "1"
+  # Use the reaperc2 ServiceAccount IAM role (IRSA). See examples/bedrock-irsa.md.
+  REAPER_AI_BEDROCK_USE_IAM: "1"
   # Inference profile IDs (see pkg/ai/bedrock_models.go):
   # REAPER_AI_BEDROCK_MODELS: "us.anthropic.claude-sonnet-4-6,us.anthropic.claude-opus-4-7"
   # Or one unified list (overrides per-provider *_MODELS when set):

--- a/deployments/k8s/AWS/deployment.yaml
+++ b/deployments/k8s/AWS/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: reaperc2-deployment
     spec:
+      serviceAccountName: reaperc2
       containers:
         - name: reaperc2-deployment
           image: 123456789012.dkr.ecr.us-east-1.amazonaws.com/reaperc2:latest
@@ -67,6 +68,18 @@ spec:
               value: "/etc/ssl/certs/rds-combined-ca-bundle.pem"
             - name: REAPERC2_ROOT
               value: "/root"
+            - name: ADMIN_BOOTSTRAP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: reaperc2-admin-bootstrap
+                  key: username
+                  optional: true
+            - name: ADMIN_BOOTSTRAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: reaperc2-admin-bootstrap
+                  key: password
+                  optional: true
           envFrom:
             - configMapRef:
                 name: reaperc2-ai-config

--- a/deployments/k8s/AWS/examples/README.md
+++ b/deployments/k8s/AWS/examples/README.md
@@ -5,7 +5,8 @@ Files here use **placeholders only**. Copy to `*.local.yaml`, edit, apply the **
 ```bash
 cp documentdb-secret.yaml documentdb-secret.local.yaml
 cp documentdb-admin-secret.yaml documentdb-admin-secret.local.yaml
-# Edit both .local files, then apply (see ../README.md).
+cp admin-bootstrap-secret.yaml admin-bootstrap-secret.local.yaml
+# Edit all .local files, then apply (see ../README.md).
 ```
 
 `*.local.yaml` is gitignored — never commit real hostnames or passwords.
@@ -21,5 +22,18 @@ cp documentdb-admin-secret.yaml documentdb-admin-secret.local.yaml
 **Common mistake:** `database: reaperc2_db` with `auth_source: api_db` → authentication fails.
 
 After you change the password in `.local.yaml`, re-run **`docdb-init-user-job`** (it updates the password if the user already exists). See [../README.md#sync-documentdb-password](../README.md#sync-documentdb-password).
+
+## `admin-bootstrap-secret.local.yaml`
+
+| Key | Rule |
+|-----|------|
+| `username` | First admin UI login when no operators exist in MongoDB |
+| `password` | Stored as Argon2id on first startup only |
+
+Not used for DocumentDB. After the first operator exists, bootstrap env vars are ignored on later restarts (you can delete the secret).
+
+## Bedrock (Operator AI)
+
+See [bedrock-irsa.md](bedrock-irsa.md) and [bedrock-iam-policy.json](bedrock-iam-policy.json). Do not grant Bedrock on the EKS node group role unless you accept cluster-wide exposure.
 
 For ECR pull credentials, use the commands in `registry-secret.yaml` (no Secret manifest in git).

--- a/deployments/k8s/AWS/examples/admin-bootstrap-secret.yaml
+++ b/deployments/k8s/AWS/examples/admin-bootstrap-secret.yaml
@@ -1,0 +1,12 @@
+# Template only — copy to admin-bootstrap-secret.local.yaml, set credentials, apply the .local file.
+# Used on first startup when the MongoDB operators collection is empty (admin UI login).
+# Do not commit real passwords to git.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: reaperc2-admin-bootstrap
+  namespace: reaperc2-ns
+type: Opaque
+stringData:
+  username: "admin"
+  password: "CHANGE_ME"

--- a/deployments/k8s/AWS/examples/bedrock-iam-policy.json
+++ b/deployments/k8s/AWS/examples/bedrock-iam-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BedrockConverse",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:*:123456789012:inference-profile/*"
+      ]
+    }
+  ]
+}

--- a/deployments/k8s/AWS/examples/bedrock-irsa.md
+++ b/deployments/k8s/AWS/examples/bedrock-irsa.md
@@ -1,0 +1,64 @@
+# Bedrock on EKS (IRSA)
+
+Operator AI uses the AWS credential chain when Bedrock is enabled and no static keys are in `reaperc2-ai-secrets`. Without **IRSA**, pods often pick up the **node group instance role**, which typically lacks `bedrock:InvokeModel` → `AccessDeniedException`.
+
+## Option A — IRSA (recommended)
+
+1. Enable model access in the Bedrock console for the models you need (e.g. Claude Opus 4.7 inference profile in `us-east-1`).
+
+2. Create an IAM policy from `bedrock-iam-policy.json` (replace `123456789012` with your account ID):
+
+   ```bash
+   aws iam create-policy \
+     --policy-name ReaperC2BedrockInvoke \
+     --policy-document file://examples/bedrock-iam-policy.json
+   ```
+
+3. Associate a role with the `reaperc2` ServiceAccount (replace cluster name and region):
+
+   ```bash
+   eksctl create iamserviceaccount \
+     --cluster=YOUR_CLUSTER \
+     --region=us-east-1 \
+     --namespace=reaperc2-ns \
+     --name=reaperc2 \
+     --role-name reaperc2-bedrock \
+     --attach-policy-arn arn:aws:iam::123456789012:policy/ReaperC2BedrockInvoke \
+     --approve \
+     --override-existing-serviceaccounts
+   ```
+
+   Or annotate manually after creating the role:
+
+   ```yaml
+   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/reaperc2-bedrock
+   ```
+
+4. Ensure `reaperc2-ai-config` has `REAPER_AI_BEDROCK_USE_IAM: "1"` (set in `../ai-config.yaml`).
+
+5. Rollout:
+
+   ```bash
+   kubectl apply -k ..
+   kubectl rollout restart deployment/reaperc2-deployment -n reaperc2-ns
+   ```
+
+6. Verify the pod assumes the IRSA role (not the node instance role):
+
+   ```bash
+   kubectl exec -n reaperc2-ns deployment/reaperc2-deployment -- \
+     env | grep -E '^AWS_ROLE_ARN|^AWS_WEB_IDENTITY'
+   ```
+
+## Option B — Bedrock API key or IAM user keys
+
+Apply keys via `deployments/k8s/operator-ai.yaml` (or a local patch) into `reaperc2-ai-secrets`:
+
+- **Bedrock API key:** `REAPER_AI_BEDROCK_API_KEY`
+- **IAM user:** `REAPER_AI_BEDROCK_ACCESS_KEY_ID` + `REAPER_AI_BEDROCK_SECRET_ACCESS_KEY`
+
+Do **not** attach Bedrock permissions to the node group role unless you accept that blast radius.
+
+## Inference profile IDs
+
+Use inference profile IDs in `REAPER_AI_BEDROCK_MODELS`, e.g. `us.anthropic.claude-opus-4-7`. See `docs/operator-guide-ai.md`.

--- a/deployments/k8s/AWS/kustomization.yaml
+++ b/deployments/k8s/AWS/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: reaperc2-ns
 
 resources:
   - namespace.yaml
+  - serviceaccount.yaml
   - ai-config.yaml
   - deployment.yaml
   - service.yaml

--- a/deployments/k8s/AWS/serviceaccount.yaml
+++ b/deployments/k8s/AWS/serviceaccount.yaml
@@ -1,0 +1,9 @@
+# ReaperC2 workload identity. For Bedrock on EKS, attach an IAM role via IRSA (see examples/bedrock-irsa.md).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reaperc2
+  namespace: reaperc2-ns
+  # After creating the Bedrock IAM role, uncomment and set your role ARN:
+  # annotations:
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/reaperc2-bedrock


### PR DESCRIPTION
Wire optional ADMIN_BOOTSTRAP_* from a local secret template, enable REAPER_AI_BEDROCK_USE_IAM with a reaperc2 ServiceAccount, and document IRSA setup plus node-role AccessDenied troubleshooting.