### PR TITLE
Add Claude Fable 5 to Operator AI and simplify Bedrock API key apply.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ BEACON_PUBLIC_BASE_URL=http://127.0.0.1:8080
 # REAPER_AI_MAX_TOKENS=2048
 #
 # Optional unified catalog (overrides per-provider *_MODELS lists):
-# REAPER_AI_MODELS=openai:gpt-5.5,anthropic:claude-opus-4-7,foundry:gpt-5.5,bedrock:anthropic.claude-opus-4-7,ollama:llama3.2
+# REAPER_AI_MODELS=openai:gpt-5.5,anthropic:claude-fable-5,foundry:gpt-5.5,bedrock:anthropic.claude-fable-5,ollama:llama3.2
 #
 # OpenAI (legacy REAPER_AI_API_KEY / REAPER_AI_API_URL / REAPER_AI_MODEL still work)
 # REAPER_AI_OPENAI_API_KEY=sk-...
@@ -44,7 +44,7 @@ BEACON_PUBLIC_BASE_URL=http://127.0.0.1:8080
 # REAPER_AI_ANTHROPIC_API_KEY=sk-ant-...
 # REAPER_AI_ANTHROPIC_API_URL=https://api.anthropic.com/v1
 # With ANTHROPIC_API_KEY set, REAPER_AI_ANTHROPIC_DISCOVER=1 (default) lists models from GET /v1/models.
-# REAPER_AI_ANTHROPIC_MODELS=claude-opus-4-7,claude-sonnet-4-6
+# REAPER_AI_ANTHROPIC_MODELS=claude-fable-5,claude-opus-4-7,claude-sonnet-4-6
 #
 # Azure AI Foundry (OpenAI-compatible v1 — also accepts AZURE_OPENAI_* env names)
 # REAPER_AI_FOUNDRY_API_KEY=
@@ -76,7 +76,8 @@ BEACON_PUBLIC_BASE_URL=http://127.0.0.1:8080
 # REAPER_AI_BEDROCK_ENABLED=1
 # REAPER_AI_BEDROCK_REGION=us-east-1
 # REAPER_AI_BEDROCK_USE_IAM=1
-# Claude 4.x requires inference profile IDs for Converse (us-east-1 → us.* prefix):
+# Claude 4.x uses regional inference profile IDs for Converse (us-east-1 → us.*).
+# Claude Fable 5 uses a global profile: global.anthropic.claude-fable-5 (bare anthropic.claude-fable-5 is rewritten).
 # REAPER_AI_BEDROCK_INFERENCE_PREFIX=us
-# REAPER_AI_BEDROCK_MODELS=us.anthropic.claude-opus-4-7,us.anthropic.claude-sonnet-4-6,amazon.nova-lite-v1:0
+# REAPER_AI_BEDROCK_MODELS=global.anthropic.claude-fable-5,us.anthropic.claude-opus-4-7,us.anthropic.claude-sonnet-4-6,amazon.nova-lite-v1:0
 # REAPER_AI_BEDROCK_MODEL=us.anthropic.claude-opus-4-7

--- a/deployments/k8s/operator-ai.yaml
+++ b/deployments/k8s/operator-ai.yaml
@@ -1,14 +1,15 @@
 # Operator AI for Kubernetes (ConfigMap + Secret).
 # Mirrors .env.example — one file for model catalog and API keys.
 #
-# Setup (do not commit secrets):
-#   cp deployments/k8s/operator-ai.yaml deployments/k8s/operator-ai.local.yaml
-#   # Edit operator-ai.local.yaml (keys, URLs, deployment names)
-#   kubectl apply -f deployments/k8s/operator-ai.local.yaml
-#   kubectl rollout restart deployment/reaperc2-deployment -n reaperc2-ns
+# Bedrock API key path (simplest): replace CHANGE_ME in the Secret below with your
+# console “Generate API key” value; set REAPER_AI_BEDROCK_USE_IAM to "0" in the ConfigMap.
+# Then:  kubectl apply -f deployments/k8s/operator-ai.yaml && kubectl rollout restart deployment/reaperc2-deployment -n reaperc2-ns
 #
-# AWS EKS: apply operator-ai.local.yaml instead of patching secrets.
-# Do not kubectl apply -f operator-ai.yaml (placeholders only).
+# For git: copy to operator-ai.local.yaml, edit secrets there, add operator-ai.local.yaml to .gitignore — do not commit real keys.
+#
+# EKS IRSA instead of an API key: leave REAPER_AI_BEDROCK_API_KEY empty (or remove the key),
+# set REAPER_AI_BEDROCK_USE_IAM to "1", and annotate the workload service account (see examples/bedrock-irsa.md).
+#
 # Safe apply -k for the app stack: deployments/k8s/reaperc2/overlays (no Operator AI ConfigMap in kustomize).
 #
 # Deployment must reference reaperc2-ai-config and reaperc2-ai-secrets via envFrom
@@ -26,7 +27,7 @@ data:
   REAPER_AI_MAX_TOKENS: "2048"
 
   # Optional unified catalog (foundry:/bedrock:/openai: prefixes). Discovery still adds live models.
-  # REAPER_AI_MODELS: "bedrock:us.anthropic.claude-opus-4-7,foundry:YOUR_DEPLOYMENT,openai:gpt-4o-mini"
+  # REAPER_AI_MODELS: "bedrock:global.anthropic.claude-fable-5,foundry:YOUR_DEPLOYMENT,openai:gpt-4o-mini"
 
   # --- OpenAI ---
   # REAPER_AI_OPENAI_API_URL: "https://api.openai.com/v1"
@@ -36,7 +37,7 @@ data:
   # --- Anthropic ---
   # REAPER_AI_ANTHROPIC_API_URL: "https://api.anthropic.com/v1"
   # REAPER_AI_ANTHROPIC_DISCOVER: "1"
-  # REAPER_AI_ANTHROPIC_MODELS: "claude-opus-4-7,claude-sonnet-4-6"
+  # REAPER_AI_ANTHROPIC_MODELS: "claude-fable-5,claude-opus-4-7,claude-sonnet-4-6"
 
   # --- Azure AI Foundry (resource base URL; ReaperC2 appends /openai/v1) ---
   # Use Azure deployment names in FOUNDRY_MODELS (from: az cognitiveservices account deployment list).
@@ -48,9 +49,10 @@ data:
   # --- AWS Bedrock ---
   REAPER_AI_BEDROCK_ENABLED: "1"
   REAPER_AI_BEDROCK_REGION: "us-east-1"
-  REAPER_AI_BEDROCK_USE_IAM: "1"
+  # "0" = use REAPER_AI_BEDROCK_API_KEY (Secret below). "1" = default credential chain / IRSA when no API key.
+  REAPER_AI_BEDROCK_USE_IAM: "0"
   # REAPER_AI_BEDROCK_INFERENCE_PREFIX: "us"
-  REAPER_AI_BEDROCK_MODELS: "us.anthropic.claude-opus-4-8,us.anthropic.claude-opus-4-7,us.anthropic.claude-sonnet-4-6,amazon.nova-lite-v1:0"
+  REAPER_AI_BEDROCK_MODELS: "global.anthropic.claude-fable-5,us.anthropic.claude-opus-4-8,us.anthropic.claude-opus-4-7,us.anthropic.claude-sonnet-4-6,amazon.nova-lite-v1:0"
   # REAPER_AI_BEDROCK_MODEL: "us.anthropic.claude-opus-4-7"
 
   # --- Ollama (optional in-cluster or host) ---
@@ -66,7 +68,7 @@ metadata:
   namespace: reaperc2-ns
 type: Opaque
 stringData:
-  # Fill in operator-ai.local.yaml — leave unused keys as "" or remove them.
+  # Replace CHANGE_ME values before apply. Unused keys may stay "".
 
   # OpenAI
   REAPER_AI_OPENAI_API_KEY: ""
@@ -78,8 +80,8 @@ stringData:
   REAPER_AI_FOUNDRY_API_KEY: "CHANGE_ME"
 
   # AWS Bedrock — pick one auth path:
-  # (A) Bedrock API key from AWS console (bearer)
-  REAPER_AI_BEDROCK_API_KEY: ""
+  # (A) Bedrock API key from AWS console (“Generate API key” — bearer token, not AKIA…)
+  REAPER_AI_BEDROCK_API_KEY: "CHANGE_ME"
   # (B) Temporary IAM / SSO (12h) — all three required
   REAPER_AI_BEDROCK_ACCESS_KEY_ID: ""
   REAPER_AI_BEDROCK_SECRET_ACCESS_KEY: ""

--- a/docs/operator-guide-ai.md
+++ b/docs/operator-guide-ai.md
@@ -29,26 +29,26 @@ Set on the ReaperC2 process (see `.env.example`). Configure **provider credentia
 | Anthropic | `GET /v1/models` | `REAPER_AI_ANTHROPIC_DISCOVER=0` |
 | Azure AI Foundry | `GET /openai/v1/models` (OpenAI-compatible) | `REAPER_AI_FOUNDRY_DISCOVER=0` |
 
-Discovered models are **merged** with curated latest IDs (`gpt-5.5`, `claude-opus-4-7`, etc.) and any `REAPER_AI_*_MODELS` list. They appear in the Operator AI dropdown even when using `REAPER_AI_MODELS`. Bedrock still uses explicit model IDs (enable models in the AWS console).
+Discovered models are **merged** with curated latest IDs (`gpt-5.5`, `claude-fable-5`, etc.) and any `REAPER_AI_*_MODELS` list. They appear in the Operator AI dropdown even when using `REAPER_AI_MODELS`. Bedrock still uses explicit model IDs (enable models in the AWS console).
 
 Optional comma-separated extras or overrides per provider:
 
 | Variable | Example |
 |----------|---------|
 | `REAPER_AI_OPENAI_MODELS` | `gpt-5.5,gpt-4.1` |
-| `REAPER_AI_ANTHROPIC_MODELS` | `claude-opus-4-7,claude-sonnet-4-6` |
+| `REAPER_AI_ANTHROPIC_MODELS` | `claude-fable-5,claude-opus-4-7,claude-sonnet-4-6` |
 | `REAPER_AI_FOUNDRY_MODELS` | `gpt-5.5,gpt-4.1` (deployment names on Azure) |
 | `REAPER_AI_OLLAMA_MODELS` | `llama3.2,mistral` |
-| `REAPER_AI_BEDROCK_MODELS` | `us.anthropic.claude-opus-4-7,us.anthropic.claude-sonnet-4-6,amazon.nova-lite-v1:0` |
+| `REAPER_AI_BEDROCK_MODELS` | `global.anthropic.claude-fable-5,us.anthropic.claude-opus-4-7,us.anthropic.claude-sonnet-4-6,amazon.nova-lite-v1:0` |
 | `REAPER_AI_BEDROCK_INFERENCE_PREFIX` | `us` (optional; auto from region) |
 
 Or a unified base list (discovery still adds live models for OpenAI, Anthropic, Foundry, and Ollama):
 
 ```env
-REAPER_AI_MODELS=openai:gpt-5.5,anthropic:claude-opus-4-7,foundry:gpt-5.5,bedrock:anthropic.claude-opus-4-7,ollama:llama3.2
+REAPER_AI_MODELS=openai:gpt-5.5,anthropic:claude-fable-5,foundry:gpt-5.5,bedrock:anthropic.claude-fable-5,ollama:llama3.2
 ```
 
-If discovery is off and no `*_MODELS` is set, built-in defaults include **`gpt-5.5`**, **`claude-opus-4-7`**, and **`anthropic.claude-opus-4-7`** (Bedrock). Selecting a model still requires access on that provider. Legacy single-model vars (`REAPER_AI_OPENAI_MODEL`, etc.) still work.
+If discovery is off and no `*_MODELS` is set, built-in defaults include **`gpt-5.5`**, **`claude-fable-5`**, and **`anthropic.claude-fable-5`** (Bedrock → **`global.anthropic.claude-fable-5`** via Converse). Selecting a model still requires access on that provider. Legacy single-model vars (`REAPER_AI_OPENAI_MODEL`, etc.) still work.
 
 ### OpenAI
 
@@ -84,7 +84,7 @@ Catalog id prefix: `foundry:` (aliases `azure`, `azure_foundry` in `REAPER_AI_DE
 
 ### AWS Bedrock
 
-Uses the [Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html). **Claude Opus/Sonnet 4.x** must use **inference profile** IDs (e.g. `us.anthropic.claude-opus-4-7`, `us.anthropic.claude-sonnet-4-6` in `us-east-1`), not bare `anthropic.claude-*` foundation IDs — otherwise Converse returns `on-demand throughput isn't supported`. Nova and many other models still use foundation IDs (`amazon.nova-lite-v1:0`). ReaperC2 auto-prefixes bare Claude IDs using `REAPER_AI_BEDROCK_INFERENCE_PREFIX` (default derived from region: `us`, `eu`, `jp`, `au`, `global`).
+Uses the [Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html). **Claude Opus/Sonnet 4.x** must use **regional inference profile** IDs (e.g. `us.anthropic.claude-opus-4-7`, `us.anthropic.claude-sonnet-4-6` in `us-east-1`), not bare `anthropic.claude-*` foundation IDs — otherwise Converse returns `on-demand throughput isn't supported`. **Claude Fable 5** uses a **global** inference profile: `global.anthropic.claude-fable-5` (ReaperC2 maps bare `anthropic.claude-fable-5` to that ID). Nova and many other models still use foundation IDs (`amazon.nova-lite-v1:0`). ReaperC2 auto-prefixes other bare Claude 4.x IDs using `REAPER_AI_BEDROCK_INFERENCE_PREFIX` (default derived from region: `us`, `eu`, `jp`, `au`, `global`).
 
 Reasoning models can return **`reasoningContent`** blocks (chain-of-thought) from Converse in addition to or before plain **`text`**. ReaperC2 includes reasoning text in the assistant reply so you do not see a false **`AWS Bedrock: empty message content`** when the model only populated reasoning blocks.
 

--- a/pkg/ai/bedrock_models.go
+++ b/pkg/ai/bedrock_models.go
@@ -13,6 +13,11 @@ func bedrockConverseModelID(modelID string) string {
 	if modelID == "" || bedrockAlreadyInferenceProfile(modelID) {
 		return modelID
 	}
+	lower := strings.ToLower(modelID)
+	// Claude Fable 5 uses a global inference profile on Bedrock Converse (not us./eu.*).
+	if strings.Contains(lower, "claude-fable-5") && strings.HasPrefix(lower, "anthropic.") {
+		return "global." + modelID
+	}
 	if !bedrockRequiresInferenceProfile(modelID) {
 		return modelID
 	}

--- a/pkg/ai/bedrock_models_test.go
+++ b/pkg/ai/bedrock_models_test.go
@@ -25,6 +25,16 @@ func TestBedrockConverseModelIDPassthrough(t *testing.T) {
 	}
 }
 
+func TestBedrockConverseModelIDClaudeFable5GlobalProfile(t *testing.T) {
+	t.Setenv("REAPER_AI_BEDROCK_REGION", "us-east-1")
+	if got := bedrockConverseModelID("anthropic.claude-fable-5"); got != "global.anthropic.claude-fable-5" {
+		t.Fatalf("got %q", got)
+	}
+	if got := bedrockConverseModelID("global.anthropic.claude-fable-5"); got != "global.anthropic.claude-fable-5" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestBedrockInferenceProfilePrefixEU(t *testing.T) {
 	t.Setenv("REAPER_AI_BEDROCK_REGION", "eu-west-1")
 	t.Setenv("REAPER_AI_BEDROCK_INFERENCE_PREFIX", "")

--- a/pkg/ai/model_catalog.go
+++ b/pkg/ai/model_catalog.go
@@ -14,12 +14,14 @@ var (
 		"gpt-4o",
 	}
 	preferredAnthropicModels = []string{
+		"claude-fable-5",
 		"claude-opus-4-7",
 		"claude-sonnet-4-6",
 		"claude-haiku-4-5-20251001",
 	}
-	// Base foundation model IDs; resolved to inference profiles (e.g. us.anthropic.*) at runtime.
+	// Base foundation model IDs; resolved to inference profiles (e.g. us.anthropic.*, global.anthropic.*) at runtime.
 	preferredBedrockModels = []string{
+		"anthropic.claude-fable-5",
 		"anthropic.claude-opus-4-7",
 		"anthropic.claude-sonnet-4-6",
 		"anthropic.claude-haiku-4-5-20251001-v1:0",

--- a/pkg/ai/remote_discover_test.go
+++ b/pkg/ai/remote_discover_test.go
@@ -72,7 +72,7 @@ func TestDiscoverAnthropicModels(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(names) != 3 || names[0] != "claude-opus-4-7" {
+	if len(names) != 4 || names[0] != "claude-fable-5" {
 		t.Fatalf("names = %#v", names)
 	}
 }
@@ -99,7 +99,7 @@ func TestAnthropicModelNamesMergedDiscoverOffUsesDefaults(t *testing.T) {
 	t.Setenv("REAPER_AI_ANTHROPIC_MODEL", "")
 
 	names := anthropicModelNamesMerged()
-	if len(names) != 3 || names[0] != "claude-opus-4-7" {
+	if len(names) != 4 || names[0] != "claude-fable-5" {
 		t.Fatalf("names = %#v", names)
 	}
 }


### PR DESCRIPTION
Map bare anthropic.claude-fable-5 to global.anthropic.claude-fable-5 for Bedrock Converse; extend curated catalogs and docs/.env examples. operator-ai.yaml now defaults to API key auth with CHANGE_ME placeholders and apply+rollout notes.